### PR TITLE
support Flash attention

### DIFF
--- a/omnivoice/cli/infer.py
+++ b/omnivoice/cli/infer.py
@@ -116,7 +116,7 @@ def get_parser() -> argparse.ArgumentParser:
         help="Device to use for inference. Auto-detected if not specified.",
     )
     parser.add_argument(
-        "--use-flash-attn",
+        "--use_flash_attn",
         action="store_true",
         default=False,
         help='Use FlashAttention-2 for faster inference. '

--- a/omnivoice/cli/infer.py
+++ b/omnivoice/cli/infer.py
@@ -115,6 +115,13 @@ def get_parser() -> argparse.ArgumentParser:
         default=None,
         help="Device to use for inference. Auto-detected if not specified.",
     )
+    parser.add_argument(
+        "--use-flash-attn",
+        action="store_true",
+        default=False,
+        help='Use FlashAttention-2 for faster inference. '
+        'Requires flash-attn to be installed.',
+    )
     return parser
 
 
@@ -126,8 +133,13 @@ def main():
 
     device = args.device or get_best_device()
     logging.info(f"Loading model from {args.model} on {device} ...")
+
+    extra_kwargs = {}
+    if args.use_flash_attn:
+        extra_kwargs["attn_implementation"] = "flash_attention_2"
+
     model = OmniVoice.from_pretrained(
-        args.model, device_map=device, dtype=torch.float16
+        args.model, device_map=device, dtype=torch.float16, **extra_kwargs
     )
 
     logging.info(f"Generating audio for: {args.text[:80]}...")

--- a/omnivoice/cli/infer_batch.py
+++ b/omnivoice/cli/infer_batch.py
@@ -197,10 +197,17 @@ def get_parser():
         "language_id/language_name fields. If provided, both language_id and "
         "language_name will be set to this value.",
     )
+    parser.add_argument(
+        "--use-flash-attn",
+        action="store_true",
+        default=False,
+        help='Use FlashAttention-2 for faster inference. '
+        'Requires flash-attn to be installed.',
+    )
     return parser
 
 
-def process_init(rank_queue, model_checkpoint, warmup=0):
+def process_init(rank_queue, model_checkpoint, warmup=0, attn_implementation=None):
     """Initializer for each worker process.
 
     Loads model (with tokenizers and duration estimator) onto a specific GPU
@@ -228,10 +235,15 @@ def process_init(rank_queue, model_checkpoint, warmup=0):
 
     logging.info(f"Initializing worker on device: {worker_device}")
 
+    extra_kwargs = {}
+    if attn_implementation is not None:
+        extra_kwargs["attn_implementation"] = attn_implementation
+
     worker_model = OmniVoice.from_pretrained(
         model_checkpoint,
         device_map=worker_device,
         dtype=torch.float16,
+        **extra_kwargs,
     )
 
     if warmup > 0:
@@ -453,7 +465,8 @@ def main():
         with ProcessPoolExecutor(
             max_workers=num_processes,
             initializer=process_init,
-            initargs=(rank_queue, args.model, args.warmup),
+            initargs=(rank_queue, args.model, args.warmup,
+                      "flash_attention_2" if args.use_flash_attn else None),
         ) as executor:
             futures = []
 

--- a/omnivoice/cli/infer_batch.py
+++ b/omnivoice/cli/infer_batch.py
@@ -198,7 +198,7 @@ def get_parser():
         "language_name will be set to this value.",
     )
     parser.add_argument(
-        "--use-flash-attn",
+        "--use_flash_attn",
         action="store_true",
         default=False,
         help='Use FlashAttention-2 for faster inference. '

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -375,6 +375,7 @@ class OmniVoice(PreTrainedModel):
         attention_mask: Optional[torch.Tensor] = None,
         document_ids: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        **kwargs,
     ):
 
         inputs_embeds = self._prepare_embed_inputs(input_ids, audio_mask)
@@ -397,6 +398,7 @@ class OmniVoice(PreTrainedModel):
             attention_mask=attention_mask,
             return_dict=True,
             position_ids=position_ids,
+            **kwargs,
         )
         hidden_states = llm_outputs[0]
 
@@ -1169,9 +1171,18 @@ class OmniVoice(PreTrainedModel):
         batch_audio_mask = torch.zeros(
             (2 * B, max_c_len), dtype=torch.bool, device=self.device
         )
-        batch_attention_mask = torch.zeros(
-            (2 * B, 1, max_c_len, max_c_len), dtype=torch.bool, device=self.device
-        )
+        use_flash = getattr(self.llm.config, "_attn_implementation", None) == "flash_attention_2"
+
+        if use_flash:
+            # 2D padding mask — flash_attention_2 internally handles unpad + varlen
+            batch_attention_mask = torch.zeros(
+                (2 * B, max_c_len), dtype=torch.bool, device=self.device
+            )
+        else:
+            # 4D bidirectional mask — for SDPA/eager fallback
+            batch_attention_mask = torch.zeros(
+                (2 * B, 1, max_c_len, max_c_len), dtype=torch.bool, device=self.device
+            )
 
         for i, inp in enumerate(inputs_list):
             c_len, u_len = c_lens[i], task.target_lens[i]
@@ -1179,15 +1190,18 @@ class OmniVoice(PreTrainedModel):
             # Cond (0 ~ B-1)
             batch_input_ids[i, :, :c_len] = inp["input_ids"]
             batch_audio_mask[i, :c_len] = inp["audio_mask"]
-            batch_attention_mask[i, :, :c_len, :c_len] = True
+            if use_flash:
+                batch_attention_mask[i, :c_len] = True
+            else:
+                batch_attention_mask[i, :, :c_len, :c_len] = True
 
             # Uncond (B ~ 2B-1)
             batch_input_ids[B + i, :, :u_len] = inp["input_ids"][..., -u_len:]
             batch_audio_mask[B + i, :u_len] = inp["audio_mask"][..., -u_len:]
-            batch_attention_mask[B + i, :, :u_len, :u_len] = True
-            if max_c_len > u_len:
-                pad_diag = torch.arange(u_len, max_c_len, device=self.device)
-                batch_attention_mask[B + i, :, pad_diag, pad_diag] = True
+            if use_flash:
+                batch_attention_mask[B + i, :u_len] = True
+            else:
+                batch_attention_mask[B + i, :, :u_len, :u_len] = True
 
         tokens = torch.full(
             (B, self.config.num_audio_codebook, max(task.target_lens)),
@@ -1224,11 +1238,16 @@ class OmniVoice(PreTrainedModel):
             self.config.num_audio_codebook, device=self.device
         ).view(1, -1, 1)
 
+        forward_kwargs = {}
+        if use_flash:
+            forward_kwargs["is_causal"] = False
+
         for step in range(gen_config.num_step):
             batch_logits = self(
                 input_ids=batch_input_ids,
                 audio_mask=batch_audio_mask,
                 attention_mask=batch_attention_mask,
+                **forward_kwargs,
             ).logits.to(torch.float32)
 
             for i in range(B):


### PR DESCRIPTION
## Flash Attention Support

Tested with 50 randomly distributed audio samples, randomly grouped into batches of 4.

FlashAttention-2 with packed input (varlen) avoids redundant computation on padding tokens, reducing inference time:

| GPU | w/o flash_attn | w/ flash_attn | Speedup |
|-----|---------------|--------------|---------|
| L20 | 29s | 26s | ~10% |
| H20 | 25s | 23s | ~8% |

Usage:
```bash
omnivoice-infer-batch --use_flash_attn --batch_size 4 ...
```
