### PR TITLE
docs: restore omnivoice-server to community projects (after force-push)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ You can also scan the QR code to join our wechat group or follow our wechat offi
 
 ---
 
+## Community Projects
+
+- **[omnivoice-server](https://github.com/maemreyo/omnivoice-server)** —
+  OpenAI-compatible HTTP server for serving OmniVoice via `/v1/audio/speech`.
+  Supports voice profiles for persistent cloning, sentence-level streaming,
+  and optional Bearer auth.
+
+---
+
 ## Citation
 
 ```bibtex


### PR DESCRIPTION
This PR restores the Community Projects section that was accidentally removed during a force-push (commit `682fd36` → `a4068c8`) in a previous PR.

The original change added `omnivoice-server` to the community projects list with documentation about its OpenAI-compatible HTTP interface for serving OmniVoice.

cc @zhu-han