### PR TITLE
docs: add omnivoice-rs to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ You can also scan the QR code to join our wechat group or follow our wechat offi
   Supports voice profiles for persistent cloning, sentence-level streaming,
   and optional Bearer auth.
 
+- **[omnivoice-rs](https://github.com/FerrisMind/omnivoice-rs)** —
+  GPU-first Rust workspace for OmniVoice inference, parity validation, CLI
+  execution, and an OpenAI-compatible HTTP server built with Candle.
+
 ---
 
 ## Citation


### PR DESCRIPTION
Hi! This PR adds `omnivoice-rs` to the README's Community Projects section so it's a little easier for people exploring OmniVoice to discover the Rust port from the main repository.

I've included the current repository link and a short description of what the project covers today: OmniVoice inference, parity validation, CLI tooling, and the OpenAI-compatible HTTP server built with Candle.

Just a small documentation update, but it should make the Rust project easier to find for anyone interested in the broader OmniVoice ecosystem
