### PR TITLE
docs: add omnivoice-trtllm to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ You can also scan the QR code to join our wechat group or follow our wechat offi
   GPU-first Rust workspace for OmniVoice inference, parity validation, CLI
   execution, and an OpenAI-compatible HTTP server built with Candle.
 
+- **[omnivoice-trtllm](https://github.com/tlitech/omnivoice-trtllm)** —
+  Deploy OmniVoice TTS model using TensorRT-LLM and Triton Inference Server
+  on Modal, faster than PyTorch.
+
 ---
 
 ## Citation


### PR DESCRIPTION
Deploy OmniVoice TTS model using Triton Inference Server on Modal.

Supports two inference backends:

- PyTorch — zero setup, works out of the box
- TRT-LLM — faster inference via TensorRT-LLM engine for the Qwen3 backbone