### PR TITLE
feat: streaming TTS generation and persistent voice library

### DIFF
--- a/API_ENDPOINTS.md
+++ b/API_ENDPOINTS.md
@@ -1,0 +1,496 @@
+# OmniVoice API — Эндпоинты
+
+## Запуск сервера
+
+```bash
+pip install omnivoice[api]
+
+omnivoice-api \
+  --model k2-fsa/OmniVoice \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --library-dir /srv/voices \
+  --api-key mysecretkey
+
+# Swagger UI (интерактивная документация)
+# http://localhost:8000/docs
+```
+
+---
+
+## Аутентификация
+
+Если сервер запущен с `--api-key`, все запросы должны содержать заголовок:
+
+```
+X-Api-Key: mysecretkey
+```
+
+Без ключа — возвращает `401 Unauthorized`.
+
+---
+
+## Система
+
+### GET /health
+Проверка работоспособности сервера.
+
+**Ответ:**
+```json
+{
+  "status": "ok",
+  "sample_rate": 24000,
+  "device": "cuda:0",
+  "voices_count": 5
+}
+```
+
+---
+
+### GET /info
+Подробная информация о модели и библиотеке голосов.
+
+**Ответ:**
+```json
+{
+  "model": "k2-fsa/OmniVoice",
+  "sample_rate": 24000,
+  "device": "cuda:0",
+  "supported_languages": 617,
+  "library_dir": "/srv/voices",
+  "voices": ["Alice", "Bob", "Narrator RU"]
+}
+```
+
+---
+
+## Голоса
+
+### GET /voices
+Список всех сохранённых голосов с метаданными.
+
+**Заголовки:** `X-Api-Key`
+
+**Ответ:**
+```json
+{
+  "voices": [
+    {
+      "name": "Alice",
+      "safe_name": "Alice",
+      "ref_text": "Hello, my name is Alice.",
+      "ref_rms": 0.082
+    },
+    {
+      "name": "Narrator RU",
+      "safe_name": "Narrator_RU",
+      "ref_text": "Добрый день, дорогие слушатели.",
+      "ref_rms": 0.091
+    }
+  ],
+  "count": 2
+}
+```
+
+---
+
+### GET /voices/{name}
+Метаданные одного голоса по имени.
+
+**Параметры пути:** `name` — имя голоса (точное совпадение)
+
+**Заголовки:** `X-Api-Key`
+
+**Ответ `200`:**
+```json
+{
+  "name": "Alice",
+  "safe_name": "Alice",
+  "ref_text": "Hello, my name is Alice.",
+  "ref_rms": 0.082
+}
+```
+
+**Ответ `404`:**
+```json
+{ "detail": "Voice 'Alice' not found." }
+```
+
+---
+
+### POST /voices/clone
+Клонировать голос из загруженного аудиофайла и сохранить в библиотеку.
+
+**Заголовки:** `X-Api-Key`, `Content-Type: multipart/form-data`
+
+**Тело (form-data):**
+
+| Поле | Тип | Обязательно | Описание |
+|------|-----|:-----------:|----------|
+| `name` | string | ✅ | Имя голоса (уникальное) |
+| `audio` | file | ✅ | Аудиофайл WAV / MP3 / FLAC (рекомендуется 3–10 сек) |
+| `ref_text` | string | — | Транскрипция аудио. Если не указана — авто-транскрипция через Whisper |
+| `preprocess` | bool | — | Обрезать тишину и нормализовать громкость (по умолч. `true`) |
+
+**Ответ `201`:**
+```json
+{
+  "name": "Alice",
+  "safe_name": "Alice",
+  "ref_text": "Hello, my name is Alice.",
+  "ref_rms": 0.082
+}
+```
+
+**Ответ `409`** — голос с таким именем уже существует.
+
+**Пример:**
+```bash
+curl -X POST http://localhost:8000/voices/clone \
+  -H "X-Api-Key: mysecretkey" \
+  -F "name=Alice" \
+  -F "audio=@speaker.wav" \
+  -F "ref_text=Hello my name is Alice" \
+  -F "preprocess=true"
+```
+
+---
+
+### DELETE /voices/{name}
+Удалить голос из библиотеки.
+
+**Заголовки:** `X-Api-Key`
+
+**Ответ `200`:**
+```json
+{ "deleted": true, "name": "Alice" }
+```
+
+**Ответ `404`:**
+```json
+{ "detail": "Voice 'Alice' not found." }
+```
+
+**Пример:**
+```bash
+curl -X DELETE http://localhost:8000/voices/Alice \
+  -H "X-Api-Key: mysecretkey"
+```
+
+---
+
+### PATCH /voices/{name}
+Переименовать голос.
+
+**Заголовки:** `X-Api-Key`, `Content-Type: application/json`
+
+**Тело:**
+```json
+{ "new_name": "Alice UK" }
+```
+
+**Ответ `200`** — метаданные с новым именем.
+
+**Ответ `404`** — голос не найден.
+
+**Ответ `409`** — голос с новым именем уже существует.
+
+**Пример:**
+```bash
+curl -X PATCH http://localhost:8000/voices/Alice \
+  -H "X-Api-Key: mysecretkey" \
+  -H "Content-Type: application/json" \
+  -d '{"new_name": "Alice UK"}'
+```
+
+---
+
+## Генерация
+
+Общие параметры тела запроса для всех эндпоинтов генерации:
+
+| Поле | Тип | По умолч. | Описание |
+|------|-----|:---------:|----------|
+| `text` | string | — | Текст для синтеза (обязательно, макс. 10 000 символов) |
+| `voice` | string | `null` | Имя голоса из библиотеки. `null` — без голоса (авто-режим) |
+| `language` | string | `null` | Язык: `"Russian"`, `"English"`, `"zh"` и т.д. `null` — авто-определение |
+| `instruct` | string | `null` | Инструкция для дизайна голоса: `"male, british accent"` |
+| `speed` | float | `null` | Скорость речи: `0.3`–`3.0`. `null` — авто |
+| `duration` | float | `null` | Фиксированная длина в секундах (переопределяет `speed`) |
+| `num_step` | int | `32` | Шаги диффузии: `4`–`64`. Меньше = быстрее, больше = качественнее |
+| `guidance_scale` | float | `2.0` | Сила CFG guidance: `0.0`–`4.0` |
+| `denoise` | bool | `true` | Шумоподавление |
+| `postprocess_output` | bool | `true` | Удалять длинные паузы из результата |
+| `audio_chunk_duration` | float | `15.0` | Секунд на чанк при длинных текстах |
+| `audio_chunk_threshold` | float | `30.0` | Порог (сек) включения чанкинга |
+
+---
+
+### POST /generate
+Синхронная генерация — возвращает полный WAV файл.
+
+Подходит для коротких текстов или когда нужен файл целиком перед воспроизведением.
+
+**Заголовки:** `X-Api-Key`, `Content-Type: application/json`
+
+**Ответ `200`:** бинарный WAV файл (`audio/wav`)
+
+**Заголовки ответа:**
+- `X-Sample-Rate` — частота дискретизации (например `24000`)
+- `X-Audio-Duration` — длина аудио в секундах (например `3.520`)
+- `Content-Disposition` — `attachment; filename="output.wav"`
+
+**Пример:**
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H "X-Api-Key: mysecretkey" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Привет! Это тест голосового синтеза.",
+    "voice": "Alice",
+    "language": "Russian",
+    "speed": 1.0,
+    "num_step": 32
+  }' \
+  --output output.wav
+```
+
+**Python:**
+```python
+import requests
+
+resp = requests.post(
+    "http://localhost:8000/generate",
+    headers={"X-Api-Key": "mysecretkey"},
+    json={
+        "text": "Hello world",
+        "voice": "Alice",
+        "language": "English",
+    },
+)
+with open("output.wav", "wb") as f:
+    f.write(resp.content)
+```
+
+---
+
+### POST /generate/stream
+Потоковая генерация — возвращает аудио по мере готовности чанками.
+
+Используйте для длинных текстов или когда нужно начать воспроизведение не дожидаясь окончания генерации.
+
+**Заголовки:** `X-Api-Key`, `Content-Type: application/json`
+
+**Ответ `200`:** `application/octet-stream` с `Transfer-Encoding: chunked`
+
+**Заголовки ответа:**
+- `X-Sample-Rate` — частота дискретизации (например `24000`)
+- `X-Voice` — имя использованного голоса
+
+**Формат бинарного потока:**
+
+Поток состоит из фреймов. Каждый фрейм:
+```
+[4 байта uint32-LE: длина PCM данных] [N байт: PCM int16-LE моно]
+```
+Последний фрейм — маркер конца потока:
+```
+[4 байта: 0x00000000]
+```
+
+Каждый фрейм содержит **только новый** аудио-сегмент с момента последнего фрейма.
+Для получения полного аудио — конкатенируйте все PCM-данные всех фреймов.
+
+**Python-клиент:**
+```python
+import struct, requests, numpy as np, soundfile as sf
+
+resp = requests.post(
+    "http://localhost:8000/generate/stream",
+    headers={"X-Api-Key": "mysecretkey"},
+    json={"text": "Длинный текст для стриминга...", "voice": "Alice"},
+    stream=True,
+)
+
+sr = int(resp.headers["X-Sample-Rate"])
+pcm_parts = []
+buf = b""
+
+for raw_chunk in resp.iter_content(chunk_size=8192):
+    buf += raw_chunk
+    while len(buf) >= 4:
+        frame_len = struct.unpack("<I", buf[:4])[0]
+        if frame_len == 0:             # конец потока
+            break
+        if len(buf) < 4 + frame_len:  # ждём ещё данных
+            break
+        pcm = np.frombuffer(buf[4:4 + frame_len], dtype=np.int16)
+        pcm_parts.append(pcm)
+        buf = buf[4 + frame_len:]
+        # Можно воспроизводить pcm прямо здесь (sounddevice.play)
+
+audio = np.concatenate(pcm_parts).astype(np.float32) / 32767.0
+sf.write("output.wav", audio, sr)
+```
+
+---
+
+### WS /ws/generate
+WebSocket стриминг — двунаправленный канал для real-time воспроизведения в браузере или приложении.
+
+**URL:** `ws://localhost:8000/ws/generate`
+
+#### Клиент → Сервер (один раз, JSON):
+```json
+{
+  "api_key": "mysecretkey",
+  "text": "Текст для синтеза",
+  "voice": "Alice",
+  "language": "Russian",
+  "speed": 1.0,
+  "num_step": 32,
+  "guidance_scale": 2.0
+}
+```
+Все поля из таблицы параметров генерации поддерживаются. `api_key` — только для WebSocket (заголовок здесь недоступен).
+
+#### Сервер → Клиент (поток сообщений):
+
+**Бинарные фреймы** — сырой PCM int16-LE моно, только новый сегмент:
+```
+<binary: PCM int16-LE>
+```
+
+**Текстовые фреймы** (JSON) — между бинарными чанками:
+```json
+{ "type": "status", "message": "Generating... chunk 2/5", "chunk": 2, "total": 5 }
+```
+
+Финальное сообщение:
+```json
+{ "type": "done", "duration": 12.48, "sample_rate": 24000 }
+```
+
+Сообщение об ошибке:
+```json
+{ "type": "error", "message": "Voice 'Alice' not found in library." }
+```
+
+**JavaScript-клиент (браузер):**
+```javascript
+const ws = new WebSocket("ws://localhost:8000/ws/generate");
+const audioContext = new AudioContext({ sampleRate: 24000 });
+const pcmChunks = [];
+
+ws.onopen = () => {
+    ws.send(JSON.stringify({
+        api_key: "mysecretkey",
+        text: "Hello! This is real-time streaming TTS.",
+        voice: "Alice",
+        language: "English",
+    }));
+};
+
+ws.onmessage = async (e) => {
+    if (e.data instanceof Blob) {
+        // Новый аудио-чанк
+        const buf = await e.data.arrayBuffer();
+        const pcm = new Int16Array(buf);
+        const float32 = new Float32Array(pcm.length);
+        for (let i = 0; i < pcm.length; i++) float32[i] = pcm[i] / 32767;
+
+        const audioBuf = audioContext.createBuffer(1, float32.length, 24000);
+        audioBuf.getChannelData(0).set(float32);
+
+        const source = audioContext.createBufferSource();
+        source.buffer = audioBuf;
+        source.connect(audioContext.destination);
+        source.start();
+
+        pcmChunks.push(pcm);
+    } else {
+        const msg = JSON.parse(e.data);
+        if (msg.type === "status") {
+            console.log(msg.message);  // "Generating... chunk 1/3"
+        } else if (msg.type === "done") {
+            console.log(`Done! Duration: ${msg.duration}s`);
+            ws.close();
+        } else if (msg.type === "error") {
+            console.error("Error:", msg.message);
+            ws.close();
+        }
+    }
+};
+```
+
+**Python asyncio-клиент:**
+```python
+import asyncio, json
+import numpy as np
+import websockets
+
+async def stream_tts():
+    async with websockets.connect("ws://localhost:8000/ws/generate") as ws:
+        await ws.send(json.dumps({
+            "api_key": "mysecretkey",
+            "text": "Длинный текст для WebSocket стриминга...",
+            "voice": "Alice",
+            "language": "Russian",
+        }))
+
+        pcm_parts = []
+        async for message in ws:
+            if isinstance(message, bytes):
+                pcm = np.frombuffer(message, dtype=np.int16)
+                pcm_parts.append(pcm)
+                print(f"  Received {len(pcm)/24000:.2f}s of audio")
+            else:
+                msg = json.loads(message)
+                print(f"  Status: {msg}")
+                if msg["type"] == "done":
+                    break
+
+        audio = np.concatenate(pcm_parts).astype(np.float32) / 32767.0
+        import soundfile as sf
+        sf.write("output.wav", audio, 24000)
+        print("Saved output.wav")
+
+asyncio.run(stream_tts())
+```
+
+---
+
+## Коды ответов
+
+| Код | Значение |
+|-----|----------|
+| `200` | Успех |
+| `201` | Голос создан |
+| `401` | Неверный или отсутствующий API ключ |
+| `404` | Голос не найден |
+| `409` | Конфликт — голос с таким именем уже существует |
+| `422` | Ошибка валидации параметров |
+| `500` | Ошибка сервера (генерация или клонирование) |
+| `503` | Модель ещё не загружена |
+
+---
+
+## Docker
+
+```dockerfile
+FROM python:3.11-slim
+RUN pip install omnivoice[api]
+ENV OMNIVOICE_MODEL=k2-fsa/OmniVoice
+ENV OMNIVOICE_LIBRARY_DIR=/data/voices
+ENV OMNIVOICE_API_KEY=changeme
+EXPOSE 8000
+CMD ["omnivoice-api", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+```bash
+docker build -t omnivoice-api .
+docker run -p 8000:8000 \
+  -v /srv/voices:/data/voices \
+  --gpus all \
+  omnivoice-api
+```

--- a/API_INTEGRATION.md
+++ b/API_INTEGRATION.md
@@ -1,0 +1,377 @@
+# OmniVoice — Полная инструкция по API интеграции
+
+## 0. Установка и импорты
+
+```python
+# Установка (если ещё не сделано)
+# pip install omnivoice
+
+import numpy as np
+import soundfile as sf
+import torch
+
+from omnivoice import OmniVoice, OmniVoiceGenerationConfig
+from omnivoice.utils.voice_library import VoiceLibrary
+```
+
+---
+
+## 1. Загрузка модели (один раз при старте)
+
+```python
+model = OmniVoice.from_pretrained(
+    "k2-fsa/OmniVoice",       # или локальный путь
+    device_map="cuda",         # "cuda" / "cpu" / "mps" (Apple)
+    dtype=torch.float16,       # float16 для GPU, float32 для CPU
+    load_asr=True,             # Whisper для авто-транскрипции референса
+    asr_model_name="openai/whisper-large-v3-turbo",
+)
+
+SAMPLE_RATE = model.sampling_rate  # 24000 Гц
+```
+
+---
+
+## 2. VoiceLibrary — управление голосами
+
+```python
+# Хранилище голосов (по умолчанию ~/.omnivoice/voices/)
+lib = VoiceLibrary()
+
+# Или своя папка:
+lib = VoiceLibrary("/srv/myapp/voices")
+```
+
+### 2.1 Получить список доступных голосов
+
+```python
+# Просто список имён
+names = lib.names()
+print(names)
+# ['Alice', 'Bob', 'Narrator RU']
+
+# Полные метаданные (имя, ref_text, ref_rms)
+voices = lib.list_voices()
+for v in voices:
+    print(f"  {v['name']:20s}  ref: {v['ref_text'][:50]}")
+# Alice                 ref: Hello, my name is Alice and I work at...
+# Bob                   ref: Good morning everyone, let me start...
+
+# Проверить существование голоса
+if lib.exists("Alice"):
+    print("есть")
+```
+
+### 2.2 Добавить новый голос (клонировать и сохранить)
+
+```python
+# Вариант А — из файла (авто-транскрипция через Whisper)
+prompt = model.create_voice_clone_prompt("speaker.wav")
+lib.save("Alice", prompt)
+
+# Вариант Б — из файла с готовым текстом (быстрее, не нужен Whisper)
+prompt = model.create_voice_clone_prompt(
+    ref_audio="speaker.wav",
+    ref_text="Hello, my name is Alice.",
+    preprocess_prompt=True,   # обрезка тишины, нормализация (рекомендуется)
+)
+lib.save("Alice", prompt)
+
+# Вариант В — из numpy-массива в памяти
+import soundfile as sf
+waveform, sr = sf.read("speaker.wav", always_2d=True)   # (channels, T)
+waveform = waveform.T                                    # -> (1, T)
+prompt = model.create_voice_clone_prompt(
+    ref_audio=(torch.from_numpy(waveform).float(), sr)
+)
+lib.save("Alice", prompt)
+```
+
+### 2.3 Загрузить голос для использования
+
+```python
+# Загрузка по имени — мгновенно, без аудиофайла
+prompt = lib.load("Alice")
+# prompt.ref_audio_tokens  — тензор (8, T) на CPU
+# prompt.ref_text           — транскрипция референса
+# prompt.ref_rms            — громкость для нормализации
+```
+
+### 2.4 Переименовать / удалить голос
+
+```python
+lib.rename("Alice", "Alice (UK)")   # переименовать
+lib.delete("Alice (UK)")            # удалить → True/False
+```
+
+---
+
+## 3. Потоковая генерация (streaming)
+
+`generate_streaming` — это **Python-генератор**. На каждой итерации отдаёт `(audio_array, status)`:
+
+- **Короткий текст** (< ~30 сек аудио): один `yield` по завершении
+- **Длинный текст**: несколько `yield` — после каждого чанка, **накопительно**
+
+### 3.1 Базовый пример
+
+```python
+prompt = lib.load("Alice")
+
+for audio, status in model.generate_streaming(
+    text="Привет! Это потоковая генерация речи с выбранным голосом.",
+    language="Russian",            # или None для авто-определения
+    voice_clone_prompt=prompt,
+):
+    print(f"[{status}]  audio shape: {audio.shape}")
+    # Последний yield — финальный результат
+    final_audio = audio
+
+# Сохранить результат
+sf.write("output.wav", final_audio, SAMPLE_RATE)
+```
+
+### 3.2 Воспроизведение в реальном времени (по чанкам)
+
+```python
+import sounddevice as sd   # pip install sounddevice
+
+prompt = lib.load("Alice")
+prev_len = 0
+
+for audio, status in model.generate_streaming(
+    text="Длинный текст, который займёт несколько секунд генерации...",
+    voice_clone_prompt=prompt,
+    generation_config=OmniVoiceGenerationConfig(
+        num_step=32,
+        audio_chunk_duration=15.0,   # секунд на чанк
+        audio_chunk_threshold=30.0,  # порог включения чанкинга
+    ),
+):
+    # Воспроизводим только НОВУЮ часть аудио
+    new_part = audio[prev_len:]
+    if len(new_part) > 0:
+        sd.play(new_part, SAMPLE_RATE, blocking=False)
+    prev_len = len(audio)
+    print(f"Status: {status}")
+```
+
+### 3.3 Стриминг в FastAPI (SSE — Server-Sent Events)
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+import io, struct, json
+
+app = FastAPI()
+
+@app.get("/tts/stream")
+async def tts_stream(
+    text: str,
+    voice: str = "Alice",
+    language: str = None,
+    speed: float = 1.0,
+):
+    """Стриминговый TTS — отдаёт WAV-чанки по мере генерации."""
+
+    def _generate():
+        try:
+            prompt = lib.load(voice)
+        except KeyError:
+            yield b""   # голос не найден
+            return
+
+        for audio, status in model.generate_streaming(
+            text=text,
+            language=language or None,
+            voice_clone_prompt=prompt,
+            speed=speed,
+        ):
+            # Конвертируем float32 → int16 WAV-байты
+            pcm = (audio * 32767).astype(np.int16).tobytes()
+            # Шлём: 4 байта длины + PCM данные
+            yield struct.pack("<I", len(pcm)) + pcm
+
+    return StreamingResponse(
+        _generate(),
+        media_type="application/octet-stream",
+        headers={"X-Sample-Rate": str(SAMPLE_RATE)},
+    )
+
+
+@app.get("/voices")
+def list_voices():
+    """Список доступных голосов."""
+    return {
+        "voices": lib.list_voices(),
+        "count": len(lib.names()),
+    }
+
+
+@app.post("/voices/{name}")
+async def add_voice(name: str, ref_audio_path: str, ref_text: str = None):
+    """Добавить голос в библиотеку."""
+    prompt = model.create_voice_clone_prompt(
+        ref_audio=ref_audio_path,
+        ref_text=ref_text or None,
+    )
+    lib.save(name, prompt)
+    return {"status": "saved", "name": name}
+
+
+@app.delete("/voices/{name}")
+def delete_voice(name: str):
+    ok = lib.delete(name)
+    return {"deleted": ok, "name": name}
+```
+
+### 3.4 WebSocket — push аудио браузеру
+
+```python
+from fastapi import WebSocket
+import asyncio
+
+@app.websocket("/tts/ws")
+async def tts_websocket(ws: WebSocket):
+    await ws.accept()
+
+    data = await ws.receive_json()
+    text   = data["text"]
+    voice  = data.get("voice", "Alice")
+    lang   = data.get("language", None)
+
+    try:
+        prompt = lib.load(voice)
+    except KeyError:
+        await ws.send_json({"error": f"Voice '{voice}' not found"})
+        await ws.close()
+        return
+
+    loop = asyncio.get_event_loop()
+
+    def _run():
+        for audio, status in model.generate_streaming(
+            text=text,
+            language=lang,
+            voice_clone_prompt=prompt,
+        ):
+            pcm = (audio * 32767).astype(np.int16).tobytes()
+            is_last = status == "Done."
+            # Блокирующий send в синхронном генераторе — шедулируем через loop
+            asyncio.run_coroutine_threadsafe(
+                ws.send_bytes(pcm), loop
+            ).result()
+            if is_last:
+                asyncio.run_coroutine_threadsafe(
+                    ws.send_json({"status": "done"}), loop
+                ).result()
+
+    await loop.run_in_executor(None, _run)
+```
+
+---
+
+## 4. Параметры генерации
+
+```python
+cfg = OmniVoiceGenerationConfig(
+    num_step=32,              # шаги диффузии: 4–64 (меньше=быстрее, больше=качественнее)
+    guidance_scale=2.0,       # сила CFG guidance (0.0–4.0)
+    speed=1.0,                # скорость речи (0.5–1.5)
+    denoise=True,             # шумоподавление (рекомендуется)
+    postprocess_output=True,  # удалять длинные паузы из результата
+    preprocess_prompt=True,   # предобработка референса
+    audio_chunk_duration=15.0,    # секунд на чанк при длинных текстах
+    audio_chunk_threshold=30.0,   # порог включения чанкинга
+)
+
+for audio, status in model.generate_streaming(
+    text="...",
+    voice_clone_prompt=prompt,
+    language="Russian",       # "English", "Chinese", "German", None...
+    speed=1.1,                # или через generation_config
+    duration=5.0,             # зафиксировать длину в секундах (переопределяет speed)
+    generation_config=cfg,
+):
+    ...
+```
+
+---
+
+## 5. Полный рабочий скрипт
+
+```python
+"""example_streaming.py — полный пример с нуля."""
+
+import numpy as np
+import soundfile as sf
+import torch
+from omnivoice import OmniVoice, OmniVoiceGenerationConfig
+from omnivoice.utils.voice_library import VoiceLibrary
+
+# 1. Загрузка
+model = OmniVoice.from_pretrained(
+    "k2-fsa/OmniVoice", device_map="cuda", dtype=torch.float16, load_asr=True
+)
+lib = VoiceLibrary()
+
+# 2. Добавить голос (один раз)
+if not lib.exists("Demo Voice"):
+    prompt = model.create_voice_clone_prompt("reference.wav")
+    lib.save("Demo Voice", prompt)
+    print("Voice saved!")
+
+# 3. Список доступных голосов
+print("Available voices:", lib.names())
+
+# 4. Потоковая генерация
+prompt = lib.load("Demo Voice")
+
+final_audio = None
+for audio, status in model.generate_streaming(
+    text=(
+        "Это демонстрация потоковой генерации речи. "
+        "Аудио обновляется по мере готовности каждого фрагмента текста."
+    ),
+    language="Russian",
+    voice_clone_prompt=prompt,
+    generation_config=OmniVoiceGenerationConfig(num_step=32, speed=1.0),
+):
+    print(f"  [{status}] got {len(audio)/24000:.2f}s of audio")
+    final_audio = audio
+
+sf.write("output.wav", final_audio, model.sampling_rate)
+print("Saved output.wav")
+```
+
+---
+
+## Шпаргалка
+
+| Задача                  | Метод                                                                 |
+|-------------------------|-----------------------------------------------------------------------|
+| Список голосов          | `lib.names()`                                                         |
+| Полные метаданные       | `lib.list_voices()`                                                   |
+| Проверить наличие       | `lib.exists("Alice")`                                                 |
+| Загрузить голос         | `lib.load("Alice")`                                                   |
+| Добавить голос          | `lib.save("Alice", model.create_voice_clone_prompt("ref.wav"))`       |
+| Переименовать           | `lib.rename("Alice", "Alice UK")`                                     |
+| Удалить                 | `lib.delete("Alice")`                                                 |
+| Потоковая генерация     | `for audio, status in model.generate_streaming(text, voice_clone_prompt=prompt)` |
+| Обычная генерация       | `audio_list = model.generate(text, voice_clone_prompt=prompt)`        |
+
+---
+
+## Структура файлов библиотеки голосов
+
+```
+~/.omnivoice/voices/          # (или ваша папка)
+    Alice.json                # метаданные: name, ref_text, ref_rms
+    Alice.pt                  # тензор ref_audio_tokens (8, T)
+    Bob.json
+    Bob.pt
+    Narrator_RU.json
+    Narrator_RU.pt
+```
+
+Файлы `.pt` можно переносить между машинами — модель и версия PyTorch должны совпадать.

--- a/omnivoice/__init__.py
+++ b/omnivoice/__init__.py
@@ -23,6 +23,14 @@ from omnivoice.models.omnivoice import (
     OmniVoice,
     OmniVoiceConfig,
     OmniVoiceGenerationConfig,
+    VoiceClonePrompt,
 )
+from omnivoice.utils.voice_library import VoiceLibrary
 
-__all__ = ["OmniVoice", "OmniVoiceConfig", "OmniVoiceGenerationConfig"]
+__all__ = [
+    "OmniVoice",
+    "OmniVoiceConfig",
+    "OmniVoiceGenerationConfig",
+    "VoiceClonePrompt",
+    "VoiceLibrary",
+]

--- a/omnivoice/api/server.py
+++ b/omnivoice/api/server.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors:  Han Zhu)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""OmniVoice REST API server.
+
+Production-ready FastAPI server exposing:
+  - Voice library management  (list / clone / delete / rename)
+  - TTS generation            (sync WAV response)
+  - Streaming TTS             (chunked HTTP or WebSocket)
+
+Usage:
+    omnivoice-api --model k2-fsa/OmniVoice --port 8000
+
+Or programmatically:
+    uvicorn omnivoice.api.server:create_app --factory --port 8000
+"""
+
+import argparse
+import io
+import logging
+import os
+import struct
+import tempfile
+import threading
+import wave
+from concurrent.futures import ThreadPoolExecutor
+from typing import AsyncIterator, Optional
+
+import numpy as np
+import torch
+import uvicorn
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response, StreamingResponse
+from pydantic import BaseModel, Field
+
+from omnivoice import OmniVoice, OmniVoiceGenerationConfig
+from omnivoice.utils.common import get_best_device
+from omnivoice.utils.voice_library import VoiceLibrary
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Global singletons (set by create_app / main)
+# ---------------------------------------------------------------------------
+_model: Optional[OmniVoice] = None
+_library: Optional[VoiceLibrary] = None
+_api_key: Optional[str] = None          # None = auth disabled
+_executor = ThreadPoolExecutor(max_workers=1)   # one generation at a time
+_gen_lock = threading.Lock()            # serialise GPU access
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+class VoiceMeta(BaseModel):
+    name: str
+    safe_name: str
+    ref_text: str
+    ref_rms: float
+
+
+class VoiceList(BaseModel):
+    voices: list[VoiceMeta]
+    count: int
+
+
+class RenameRequest(BaseModel):
+    new_name: str = Field(..., min_length=1, max_length=100)
+
+
+class GenerateRequest(BaseModel):
+    text: str = Field(..., min_length=1, max_length=10_000)
+    voice: Optional[str] = Field(None, description="Saved voice name from library")
+    language: Optional[str] = Field(None, description="Language name or ID (None = auto)")
+    instruct: Optional[str] = Field(None, description="Voice-design instruction string")
+    speed: Optional[float] = Field(None, ge=0.3, le=3.0)
+    duration: Optional[float] = Field(None, ge=0.1, le=300.0)
+    num_step: int = Field(32, ge=4, le=64)
+    guidance_scale: float = Field(2.0, ge=0.0, le=4.0)
+    denoise: bool = True
+    postprocess_output: bool = True
+    audio_chunk_duration: float = Field(15.0, ge=5.0, le=60.0)
+    audio_chunk_threshold: float = Field(30.0, ge=5.0, le=300.0)
+
+
+class HealthResponse(BaseModel):
+    status: str
+    sample_rate: int
+    device: str
+    voices_count: int
+
+
+class InfoResponse(BaseModel):
+    model: str
+    sample_rate: int
+    device: str
+    supported_languages: int
+    library_dir: str
+    voices: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _require_model():
+    if _model is None:
+        raise HTTPException(503, "Model not loaded yet.")
+    return _model
+
+
+def _require_library():
+    if _library is None:
+        raise HTTPException(503, "Voice library not initialised.")
+    return _library
+
+
+def _check_api_key(x_api_key: Optional[str] = Header(None)):
+    if _api_key and x_api_key != _api_key:
+        raise HTTPException(401, "Invalid or missing API key. Pass X-Api-Key header.")
+
+
+def _audio_to_wav_bytes(audio: np.ndarray, sample_rate: int) -> bytes:
+    """Convert 1-D float32 array to in-memory WAV bytes (PCM int16)."""
+    pcm = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)          # int16 = 2 bytes
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def _build_gen_config(req: GenerateRequest) -> OmniVoiceGenerationConfig:
+    return OmniVoiceGenerationConfig(
+        num_step=req.num_step,
+        guidance_scale=req.guidance_scale,
+        denoise=req.denoise,
+        postprocess_output=req.postprocess_output,
+        audio_chunk_duration=req.audio_chunk_duration,
+        audio_chunk_threshold=req.audio_chunk_threshold,
+    )
+
+
+def _resolve_voice_prompt(req: GenerateRequest, model: OmniVoice, lib: VoiceLibrary):
+    """Return VoiceClonePrompt or None based on request params."""
+    if req.voice:
+        if not lib.exists(req.voice):
+            raise HTTPException(404, f"Voice '{req.voice}' not found in library.")
+        return lib.load(req.voice)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+def create_app(
+    model: OmniVoice = None,
+    library: VoiceLibrary = None,
+    api_key: Optional[str] = None,
+    cors_origins: list[str] = None,
+) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Can be called programmatically or used as a factory for uvicorn:
+        uvicorn omnivoice.api.server:create_app --factory
+    """
+    global _model, _library, _api_key
+
+    # Allow factory invocation from uvicorn (reads env vars)
+    if model is None:
+        _init_from_env()
+    else:
+        _model = model
+        _library = library
+        _api_key = api_key
+
+    app = FastAPI(
+        title="OmniVoice API",
+        description=(
+            "REST API for OmniVoice TTS — voice library management, "
+            "synchronous WAV generation, streaming HTTP and WebSocket."
+        ),
+        version="1.0.0",
+        docs_url="/docs",
+        redoc_url="/redoc",
+    )
+
+    # CORS
+    origins = cors_origins or ["*"]
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    _register_routes(app)
+    return app
+
+
+def _init_from_env():
+    """Load model from env vars (for uvicorn --factory usage)."""
+    global _model, _library, _api_key
+
+    checkpoint = os.environ.get("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
+    device = os.environ.get("OMNIVOICE_DEVICE") or get_best_device()
+    library_dir = os.environ.get("OMNIVOICE_LIBRARY_DIR")
+    _api_key = os.environ.get("OMNIVOICE_API_KEY")
+    load_asr = os.environ.get("OMNIVOICE_LOAD_ASR", "1") != "0"
+
+    logger.info("Loading OmniVoice from %s on %s …", checkpoint, device)
+    _model = OmniVoice.from_pretrained(
+        checkpoint,
+        device_map=device,
+        dtype=torch.float16 if "cuda" in str(device) else torch.float32,
+        load_asr=load_asr,
+    )
+    _library = VoiceLibrary(library_dir)
+    logger.info("Model ready. Library: %s", _library.library_dir)
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+def _register_routes(app: FastAPI):
+
+    auth = [Depends(_check_api_key)]
+
+    # ------------------------------------------------------------------ #
+    #  System                                                              #
+    # ------------------------------------------------------------------ #
+
+    @app.get("/health", response_model=HealthResponse, tags=["System"])
+    def health():
+        """Check server health and basic stats."""
+        m = _require_model()
+        lib = _require_library()
+        return HealthResponse(
+            status="ok",
+            sample_rate=m.sampling_rate,
+            device=str(m.device),
+            voices_count=len(lib.names()),
+        )
+
+    @app.get("/info", response_model=InfoResponse, tags=["System"])
+    def info():
+        """Detailed model and library information."""
+        m = _require_model()
+        lib = _require_library()
+        return InfoResponse(
+            model=str(getattr(m.config, "_name_or_path", "OmniVoice")),
+            sample_rate=m.sampling_rate,
+            device=str(m.device),
+            supported_languages=len(m.supported_language_ids()),
+            library_dir=str(lib.library_dir),
+            voices=lib.names(),
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Voice Library                                                       #
+    # ------------------------------------------------------------------ #
+
+    @app.get("/voices", response_model=VoiceList, tags=["Voices"],
+             dependencies=auth)
+    def list_voices():
+        """Return all saved voice clones with metadata."""
+        lib = _require_library()
+        voices = [VoiceMeta(**v) for v in lib.list_voices()]
+        return VoiceList(voices=voices, count=len(voices))
+
+    @app.get("/voices/{name}", response_model=VoiceMeta, tags=["Voices"],
+             dependencies=auth)
+    def get_voice(name: str):
+        """Get metadata for a single voice by name."""
+        lib = _require_library()
+        if not lib.exists(name):
+            raise HTTPException(404, f"Voice '{name}' not found.")
+        meta = next(v for v in lib.list_voices() if v["name"] == name)
+        return VoiceMeta(**meta)
+
+    @app.post("/voices/clone", response_model=VoiceMeta,
+              status_code=201, tags=["Voices"], dependencies=auth)
+    async def clone_voice(
+        name: str = Form(..., description="Display name for the new voice"),
+        ref_text: Optional[str] = Form(None, description="Transcript (leave empty to auto-transcribe)"),
+        preprocess: bool = Form(True, description="Trim silence and normalise volume"),
+        audio: UploadFile = File(..., description="Reference audio file (WAV/MP3/FLAC, 3–10s recommended)"),
+    ):
+        """Clone a voice from uploaded audio and save it to the library.
+
+        The audio is processed once and stored as tokens — no audio file
+        is kept on disk after cloning.
+        """
+        m = _require_model()
+        lib = _require_library()
+
+        if lib.exists(name):
+            raise HTTPException(409, f"Voice '{name}' already exists. Delete it first or choose a different name.")
+
+        # Save upload to a temp file (model needs a path or numpy array)
+        suffix = "." + (audio.filename.rsplit(".", 1)[-1] if "." in audio.filename else "wav")
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(await audio.read())
+            tmp_path = tmp.name
+
+        try:
+            loop = __import__("asyncio").get_event_loop()
+            def _do_clone():
+                with _gen_lock:
+                    return m.create_voice_clone_prompt(
+                        ref_audio=tmp_path,
+                        ref_text=ref_text or None,
+                        preprocess_prompt=preprocess,
+                    )
+            prompt = await loop.run_in_executor(_executor, _do_clone)
+            lib.save(name, prompt)
+        except ValueError as e:
+            raise HTTPException(422, str(e))
+        except Exception as e:
+            logger.exception("Clone failed")
+            raise HTTPException(500, f"Cloning failed: {type(e).__name__}: {e}")
+        finally:
+            os.unlink(tmp_path)
+
+        meta = next(v for v in lib.list_voices() if v["name"] == name)
+        return VoiceMeta(**meta)
+
+    @app.delete("/voices/{name}", tags=["Voices"], dependencies=auth)
+    def delete_voice(name: str):
+        """Delete a saved voice from the library."""
+        lib = _require_library()
+        if not lib.exists(name):
+            raise HTTPException(404, f"Voice '{name}' not found.")
+        lib.delete(name)
+        return {"deleted": True, "name": name}
+
+    @app.patch("/voices/{name}", response_model=VoiceMeta,
+               tags=["Voices"], dependencies=auth)
+    def rename_voice(name: str, body: RenameRequest):
+        """Rename a saved voice."""
+        lib = _require_library()
+        if not lib.exists(name):
+            raise HTTPException(404, f"Voice '{name}' not found.")
+        if lib.exists(body.new_name):
+            raise HTTPException(409, f"Voice '{body.new_name}' already exists.")
+        lib.rename(name, body.new_name)
+        meta = next(v for v in lib.list_voices() if v["name"] == body.new_name)
+        return VoiceMeta(**meta)
+
+    # ------------------------------------------------------------------ #
+    #  Generation — synchronous (returns complete WAV)                     #
+    # ------------------------------------------------------------------ #
+
+    @app.post("/generate", tags=["Generate"], dependencies=auth,
+              responses={200: {"content": {"audio/wav": {}}}})
+    async def generate(req: GenerateRequest):
+        """Generate speech and return a complete WAV file.
+
+        Use this for short texts or when you need the full audio before
+        playing. For long texts or real-time playback use `/generate/stream`
+        or the WebSocket endpoint.
+        """
+        m = _require_model()
+        lib = _require_library()
+        prompt = _resolve_voice_prompt(req, m, lib)
+        cfg = _build_gen_config(req)
+
+        kw = dict(
+            text=req.text,
+            language=req.language,
+            voice_clone_prompt=prompt,
+            generation_config=cfg,
+        )
+        if req.instruct:
+            kw["instruct"] = req.instruct
+        if req.speed is not None:
+            kw["speed"] = req.speed
+        if req.duration is not None:
+            kw["duration"] = req.duration
+
+        loop = __import__("asyncio").get_event_loop()
+
+        def _do_generate():
+            with _gen_lock:
+                return m.generate(**kw)[0]
+
+        try:
+            audio = await loop.run_in_executor(_executor, _do_generate)
+        except Exception as e:
+            logger.exception("Generation failed")
+            raise HTTPException(500, f"Generation failed: {type(e).__name__}: {e}")
+
+        wav_bytes = _audio_to_wav_bytes(audio, m.sampling_rate)
+        return Response(
+            content=wav_bytes,
+            media_type="audio/wav",
+            headers={
+                "Content-Disposition": 'attachment; filename="output.wav"',
+                "X-Sample-Rate": str(m.sampling_rate),
+                "X-Audio-Duration": f"{len(audio) / m.sampling_rate:.3f}",
+            },
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Generation — streaming HTTP (chunked PCM frames)                    #
+    # ------------------------------------------------------------------ #
+
+    @app.post("/generate/stream", tags=["Generate"], dependencies=auth,
+              responses={200: {"content": {"application/octet-stream": {}}}})
+    async def generate_stream(req: GenerateRequest):
+        """Stream TTS audio as it is generated (chunk by chunk).
+
+        **Response format** — binary stream of frames:
+
+        ```
+        [4 bytes uint32-LE: frame_length] [frame_length bytes: PCM int16-LE]
+        ...repeated for each chunk...
+        [4 bytes: 0x00000000]   <- end-of-stream sentinel
+        ```
+
+        Each frame is a valid segment of audio at `X-Sample-Rate` Hz, mono,
+        int16. Concatenating all frames gives the full audio.
+
+        **Headers returned:**
+        - `X-Sample-Rate`: audio sample rate (e.g. 24000)
+        - `X-Voice`: name of the voice used (or "uploaded")
+        - `Transfer-Encoding`: chunked
+        """
+        m = _require_model()
+        lib = _require_library()
+        prompt = _resolve_voice_prompt(req, m, lib)
+        cfg = _build_gen_config(req)
+
+        kw = dict(
+            text=req.text,
+            language=req.language,
+            voice_clone_prompt=prompt,
+            generation_config=cfg,
+        )
+        if req.instruct:
+            kw["instruct"] = req.instruct
+        if req.speed is not None:
+            kw["speed"] = req.speed
+        if req.duration is not None:
+            kw["duration"] = req.duration
+
+        sample_rate = m.sampling_rate
+        prev_len = 0
+
+        async def _stream() -> AsyncIterator[bytes]:
+            nonlocal prev_len
+            loop = __import__("asyncio").get_event_loop()
+
+            # Wrap the synchronous generator in run_in_executor
+            gen = m.generate_streaming(**kw)
+
+            def _next():
+                try:
+                    return next(gen)
+                except StopIteration:
+                    return None
+
+            with _gen_lock:
+                while True:
+                    result = await loop.run_in_executor(_executor, _next)
+                    if result is None:
+                        break
+                    audio, _status = result
+                    # Only send the NEW portion since last yield
+                    new_audio = audio[prev_len:]
+                    prev_len = len(audio)
+                    if len(new_audio) == 0:
+                        continue
+                    pcm = (np.clip(new_audio, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+                    # Frame: [4-byte length][pcm bytes]
+                    yield struct.pack("<I", len(pcm)) + pcm
+
+            # End-of-stream sentinel
+            yield struct.pack("<I", 0)
+
+        return StreamingResponse(
+            _stream(),
+            media_type="application/octet-stream",
+            headers={
+                "X-Sample-Rate": str(sample_rate),
+                "X-Voice": req.voice or "none",
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",   # disable nginx buffering
+            },
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Generation — WebSocket                                              #
+    # ------------------------------------------------------------------ #
+
+    @app.websocket("/ws/generate")
+    async def ws_generate(websocket: WebSocket):
+        """WebSocket endpoint for real-time TTS streaming.
+
+        **Client sends** (JSON):
+        ```json
+        {
+          "text": "Hello world",
+          "voice": "Alice",
+          "language": "English",
+          "speed": 1.0,
+          "num_step": 32
+        }
+        ```
+
+        **Server sends** (interleaved):
+        - **Binary frames**: raw PCM int16-LE mono at 24 kHz (new audio only)
+        - **Text frames** (JSON):
+          - `{"type": "status", "message": "Generating... chunk 1/3", "chunk": 1, "total": 3}`
+          - `{"type": "done", "duration": 5.23, "sample_rate": 24000}`
+          - `{"type": "error", "message": "..."}`
+
+        **Auth**: if API key is configured, send `{"api_key": "..."}` as the
+        first JSON message before the generation request.
+        """
+        await websocket.accept()
+        m = _require_model()
+        lib = _require_library()
+        import asyncio, json as _json
+
+        try:
+            # --- Receive request ---
+            raw = await websocket.receive_text()
+            data = _json.loads(raw)
+
+            # Optional auth via WebSocket message
+            if _api_key and data.get("api_key") != _api_key:
+                await websocket.send_text(_json.dumps({"type": "error", "message": "Unauthorised"}))
+                await websocket.close(code=4001)
+                return
+
+            req = GenerateRequest(**{k: v for k, v in data.items() if k != "api_key"})
+            prompt = _resolve_voice_prompt(req, m, lib)
+            cfg = _build_gen_config(req)
+
+            kw = dict(
+                text=req.text,
+                language=req.language,
+                voice_clone_prompt=prompt,
+                generation_config=cfg,
+            )
+            if req.instruct:
+                kw["instruct"] = req.instruct
+            if req.speed is not None:
+                kw["speed"] = req.speed
+            if req.duration is not None:
+                kw["duration"] = req.duration
+
+            sample_rate = m.sampling_rate
+            prev_len = 0
+            total_audio = None
+
+            # --- Stream generation ---
+            loop = asyncio.get_event_loop()
+            gen = m.generate_streaming(**kw)
+
+            def _next_chunk():
+                try:
+                    return next(gen)
+                except StopIteration:
+                    return None
+
+            with _gen_lock:
+                while True:
+                    result = await loop.run_in_executor(_executor, _next_chunk)
+                    if result is None:
+                        break
+
+                    audio, status = result
+                    total_audio = audio
+
+                    # Send only the new audio portion
+                    new_audio = audio[prev_len:]
+                    prev_len = len(audio)
+
+                    if len(new_audio) > 0:
+                        pcm = (np.clip(new_audio, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+                        await websocket.send_bytes(pcm)
+
+                    # Parse chunk info from status string
+                    chunk_num, total_chunks = None, None
+                    if "chunk" in status:
+                        try:
+                            parts = status.split()
+                            frac = parts[-1]   # e.g. "2/5"
+                            chunk_num, total_chunks = map(int, frac.split("/"))
+                        except Exception:
+                            pass
+
+                    await websocket.send_text(_json.dumps({
+                        "type": "status",
+                        "message": status,
+                        "chunk": chunk_num,
+                        "total": total_chunks,
+                    }))
+
+            # --- Final done message ---
+            duration = len(total_audio) / sample_rate if total_audio is not None else 0.0
+            await websocket.send_text(_json.dumps({
+                "type": "done",
+                "duration": round(duration, 3),
+                "sample_rate": sample_rate,
+            }))
+
+        except WebSocketDisconnect:
+            logger.debug("WebSocket client disconnected.")
+        except HTTPException as e:
+            try:
+                import json as _json
+                await websocket.send_text(_json.dumps({"type": "error", "message": e.detail}))
+                await websocket.close()
+            except Exception:
+                pass
+        except Exception as e:
+            logger.exception("WebSocket generation error")
+            try:
+                import json as _json
+                await websocket.send_text(_json.dumps({"type": "error", "message": str(e)}))
+                await websocket.close()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="omnivoice-api",
+        description="Launch the OmniVoice REST API server.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    p.add_argument("--model", default="k2-fsa/OmniVoice",
+                   help="Model checkpoint path or HuggingFace repo id.")
+    p.add_argument("--device", default=None,
+                   help="Device (cuda / cpu / mps). Auto-detected if omitted.")
+    p.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0).")
+    p.add_argument("--port", type=int, default=8000, help="Bind port (default: 8000).")
+    p.add_argument("--library-dir", default=None,
+                   help="Voice library directory. Default: ~/.omnivoice/voices/")
+    p.add_argument("--api-key", default=None,
+                   help="If set, all endpoints require X-Api-Key header.")
+    p.add_argument("--no-asr", action="store_true", default=False,
+                   help="Skip loading Whisper ASR (auto-transcription disabled).")
+    p.add_argument("--asr-model", default="openai/whisper-large-v3-turbo",
+                   help="ASR model for reference audio transcription.")
+    p.add_argument("--workers", type=int, default=1,
+                   help="Number of uvicorn worker processes (default: 1).")
+    p.add_argument("--cors-origins", default="*",
+                   help='Allowed CORS origins, comma-separated. Default: "*".')
+    p.add_argument("--log-level", default="info",
+                   choices=["debug", "info", "warning", "error"])
+    return p
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+    )
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    device = args.device or get_best_device()
+    dtype = torch.float16 if "cuda" in str(device) else torch.float32
+
+    logger.info("Loading OmniVoice from %s on device=%s …", args.model, device)
+    model = OmniVoice.from_pretrained(
+        args.model,
+        device_map=device,
+        dtype=dtype,
+        load_asr=not args.no_asr,
+        asr_model_name=args.asr_model,
+    )
+    logger.info("Model loaded. Sample rate: %d Hz", model.sampling_rate)
+
+    library = VoiceLibrary(args.library_dir)
+    logger.info("Voice library: %s  (%d voices)", library.library_dir, len(library.names()))
+
+    cors = [o.strip() for o in args.cors_origins.split(",")]
+
+    app = create_app(
+        model=model,
+        library=library,
+        api_key=args.api_key or None,
+        cors_origins=cors,
+    )
+
+    logger.info("Starting API server on http://%s:%d", args.host, args.port)
+    logger.info("Interactive docs: http://%s:%d/docs", args.host, args.port)
+
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level,
+        workers=args.workers,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnivoice/cli/demo.py
+++ b/omnivoice/cli/demo.py
@@ -15,9 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Gradio demo for OmniVoice.
+Gradio demo for OmniVoice — with streaming generation and voice library.
 
-Supports voice cloning and voice design.
+Three tabs:
+  1. Voice Clone   — clone from uploaded audio OR saved voice; streaming output.
+  2. Voice Design  — create custom voices via speaker attributes.
+  3. Voice Library — pre-clone voices, name them, manage (list / delete).
 
 Usage:
     omnivoice-demo --model /path/to/checkpoint --port 8000
@@ -25,7 +28,7 @@ Usage:
 
 import argparse
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import gradio as gr
 import numpy as np
@@ -34,19 +37,19 @@ import torch
 from omnivoice import OmniVoice, OmniVoiceGenerationConfig
 from omnivoice.utils.common import get_best_device
 from omnivoice.utils.lang_map import LANG_NAMES, lang_display_name
-
+from omnivoice.utils.voice_library import VoiceLibrary
 
 # ---------------------------------------------------------------------------
 # Language list — all 600+ supported languages
 # ---------------------------------------------------------------------------
 _ALL_LANGUAGES = ["Auto"] + sorted(lang_display_name(n) for n in LANG_NAMES)
 
+# Sentinel shown in the saved-voice dropdown meaning "use uploaded audio"
+_UPLOAD_SENTINEL = "── Upload audio ──"
 
 # ---------------------------------------------------------------------------
 # Voice Design instruction templates
 # ---------------------------------------------------------------------------
-# Each option is displayed as "English / 中文".
-# The model expects English for accents and Chinese for dialects.
 _CATEGORIES = {
     "Gender / 性别": ["Male / 男", "Female / 女"],
     "Age / 年龄": [
@@ -97,6 +100,7 @@ _ATTR_INFO = {
     "Chinese Dialect / 中文方言": "Only effective for Chinese speech.",
 }
 
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -141,6 +145,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="ASR model path or HuggingFace repo id"
         " (default: openai/whisper-large-v3-turbo).",
     )
+    parser.add_argument(
+        "--library-dir",
+        default=None,
+        help="Directory for the voice library. Default: ~/.omnivoice/voices/",
+    )
     return parser
 
 
@@ -153,85 +162,265 @@ def build_demo(
     model: OmniVoice,
     checkpoint: str,
     generate_fn=None,
+    library_dir: Optional[str] = None,
 ) -> gr.Blocks:
 
     sampling_rate = model.sampling_rate
+    voice_lib = VoiceLibrary(library_dir)
 
-    # -- shared generation core --
-    def _gen_core(
-        text,
-        language,
-        ref_audio,
-        instruct,
-        num_step,
-        guidance_scale,
-        denoise,
-        speed,
-        duration,
-        preprocess_prompt,
-        postprocess_output,
-        mode,
-        ref_text=None,
-    ):
+    # ------------------------------------------------------------------
+    # Helper: saved-voice dropdown choices
+    # ------------------------------------------------------------------
+    def _voice_choices():
+        return [_UPLOAD_SENTINEL] + voice_lib.names()
+
+    # ------------------------------------------------------------------
+    # Helper: generation settings accordion (shared by Clone & Design tabs)
+    # ------------------------------------------------------------------
+    def _gen_settings():
+        with gr.Accordion("Generation Settings / Настройки генерации (optional)", open=False):
+            sp = gr.Slider(
+                0.5, 1.5, value=1.0, step=0.05,
+                label="Speed / Скорость",
+                info="1.0 = normal. >1 faster, <1 slower. Ignored if Duration is set.",
+            )
+            du = gr.Number(
+                value=None,
+                label="Duration / Длительность (seconds)",
+                info="Leave empty to use speed. Set a fixed duration to override speed.",
+            )
+            ns = gr.Slider(
+                4, 64, value=32, step=1,
+                label="Inference Steps / Шаги вывода",
+                info="Default: 32. Lower = faster, higher = better quality.",
+            )
+            dn = gr.Checkbox(
+                label="Denoise / Шумоподавление", value=True,
+                info="Default: enabled.",
+            )
+            gs = gr.Slider(
+                0.0, 4.0, value=2.0, step=0.1,
+                label="Guidance Scale (CFG)",
+                info="Default: 2.0.",
+            )
+            pp = gr.Checkbox(
+                label="Preprocess Prompt / Предобработка референса", value=True,
+                info="Silence removal and trimming on reference audio.",
+            )
+            po = gr.Checkbox(
+                label="Postprocess Output / Постобработка вывода", value=True,
+                info="Remove long silences from generated audio.",
+            )
+        return ns, gs, dn, sp, du, pp, po
+
+    # ------------------------------------------------------------------
+    # Voice-design instruct builder
+    # ------------------------------------------------------------------
+    def _build_instruct(groups):
+        selected = [g for g in groups if g and g != "Auto"]
+        if not selected:
+            return None
+        parts = []
+        for v in selected:
+            if " / " in v:
+                en, zh = v.split(" / ", 1)
+                parts.append(zh.strip() if "Dialect" in en else en.strip())
+            else:
+                parts.append(v)
+        return ", ".join(parts)
+
+    # ------------------------------------------------------------------
+    # Core generator: clone tab (streaming)
+    # ------------------------------------------------------------------
+    def _clone_streaming(
+        text, lang, saved_voice, ref_aud, ref_text,
+        instruct, ns, gs, dn, sp, du, pp, po,
+    ) -> Iterator[Tuple]:
         if not text or not text.strip():
-            return None, "Please enter the text to synthesize."
+            yield None, "⚠️ Please enter the text to synthesise."
+            return
+
+        # --- Resolve voice source ---
+        voice_prompt = None
+        if saved_voice and saved_voice != _UPLOAD_SENTINEL:
+            try:
+                voice_prompt = voice_lib.load(saved_voice)
+            except KeyError as e:
+                yield None, f"⚠️ {e}"
+                return
+            except Exception as e:
+                yield None, f"Error loading saved voice: {type(e).__name__}: {e}"
+                return
+        elif ref_aud:
+            try:
+                voice_prompt = model.create_voice_clone_prompt(
+                    ref_audio=ref_aud,
+                    ref_text=ref_text.strip() if ref_text else None,
+                )
+            except Exception as e:
+                yield None, f"Error processing reference audio: {type(e).__name__}: {e}"
+                return
+        else:
+            yield None, "⚠️ Please upload a reference audio or select a saved voice."
+            return
 
         gen_config = OmniVoiceGenerationConfig(
-            num_step=int(num_step or 32),
-            guidance_scale=float(guidance_scale) if guidance_scale is not None else 2.0,
-            denoise=bool(denoise) if denoise is not None else True,
-            preprocess_prompt=bool(preprocess_prompt),
-            postprocess_output=bool(postprocess_output),
+            num_step=int(ns or 32),
+            guidance_scale=float(gs) if gs is not None else 2.0,
+            denoise=bool(dn) if dn is not None else True,
+            preprocess_prompt=bool(pp),
+            postprocess_output=bool(po),
         )
 
-        lang = language if (language and language != "Auto") else None
+        lang_resolved = lang if (lang and lang != "Auto") else None
 
         kw: Dict[str, Any] = dict(
-            text=text.strip(), language=lang, generation_config=gen_config
+            text=text.strip(),
+            language=lang_resolved,
+            voice_clone_prompt=voice_prompt,
+            generation_config=gen_config,
         )
-
-        if speed is not None and float(speed) != 1.0:
-            kw["speed"] = float(speed)
-        if duration is not None and float(duration) > 0:
-            kw["duration"] = float(duration)
-
-        if mode == "clone":
-            if not ref_audio:
-                return None, "Please upload a reference audio."
-            kw["voice_clone_prompt"] = model.create_voice_clone_prompt(
-                ref_audio=ref_audio,
-                ref_text=ref_text,
-            )
-
+        if sp is not None and float(sp) != 1.0:
+            kw["speed"] = float(sp)
+        if du is not None and float(du) > 0:
+            kw["duration"] = float(du)
         if instruct and instruct.strip():
             kw["instruct"] = instruct.strip()
 
+        yield None, "⏳ Starting generation…"
         try:
-            audio = model.generate(**kw)
+            for audio, status in model.generate_streaming(**kw):
+                waveform = (audio * 32767).astype(np.int16)
+                yield (sampling_rate, waveform), status
+        except Exception as e:
+            yield None, f"Error: {type(e).__name__}: {e}"
+
+    # ------------------------------------------------------------------
+    # Core function: design tab (non-streaming, usually short)
+    # ------------------------------------------------------------------
+    def _design_fn(text, lang, ns, gs, dn, sp, du, pp, po, *groups):
+        if not text or not text.strip():
+            return None, "⚠️ Please enter the text to synthesise."
+
+        gen_config = OmniVoiceGenerationConfig(
+            num_step=int(ns or 32),
+            guidance_scale=float(gs) if gs is not None else 2.0,
+            denoise=bool(dn) if dn is not None else True,
+            preprocess_prompt=bool(pp),
+            postprocess_output=bool(po),
+        )
+        lang_resolved = lang if (lang and lang != "Auto") else None
+        instruct = _build_instruct(list(groups))
+
+        kw: Dict[str, Any] = dict(
+            text=text.strip(),
+            language=lang_resolved,
+            generation_config=gen_config,
+        )
+        if sp is not None and float(sp) != 1.0:
+            kw["speed"] = float(sp)
+        if du is not None and float(du) > 0:
+            kw["duration"] = float(du)
+        if instruct:
+            kw["instruct"] = instruct
+
+        try:
+            audio_list = model.generate(**kw)
         except Exception as e:
             return None, f"Error: {type(e).__name__}: {e}"
 
-        waveform = (audio[0] * 32767).astype(np.int16)
+        audio = audio_list[0]
+        waveform = (audio * 32767).astype(np.int16)
         return (sampling_rate, waveform), "Done."
 
-    # Allow external wrappers (e.g. spaces.GPU for ZeroGPU Spaces)
-    _gen = generate_fn if generate_fn is not None else _gen_core
+    # ------------------------------------------------------------------
+    # Voice library helpers
+    # ------------------------------------------------------------------
+    def _lib_save(name, ref_aud, ref_text, preprocess):
+        """Returns (status, table, vc_saved_update, lib_del_dd_update)."""
+        if not name or not name.strip():
+            return (
+                "⚠️ Please enter a name for the voice.",
+                _voice_table(),
+                gr.update(),
+                gr.update(),
+            )
+        if not ref_aud:
+            return (
+                "⚠️ Please upload a reference audio.",
+                _voice_table(),
+                gr.update(),
+                gr.update(),
+            )
+        name = name.strip()
+        try:
+            prompt = model.create_voice_clone_prompt(
+                ref_audio=ref_aud,
+                ref_text=ref_text.strip() if ref_text else None,
+                preprocess_prompt=bool(preprocess),
+            )
+            voice_lib.save(name, prompt)
+            new_choices = _voice_choices()
+            return (
+                f"✅ Voice '{name}' saved successfully!",
+                _voice_table(),
+                gr.update(choices=new_choices),
+                gr.update(choices=voice_lib.names()),
+            )
+        except Exception as e:
+            return (
+                f"Error: {type(e).__name__}: {e}",
+                _voice_table(),
+                gr.update(),
+                gr.update(),
+            )
 
-    # =====================================================================
-    # UI
-    # =====================================================================
-    theme = gr.themes.Soft(
-        font=["Inter", "Arial", "sans-serif"],
-    )
+    def _lib_delete(name):
+        if not name or name == _UPLOAD_SENTINEL:
+            return "⚠️ Please select a voice to delete.", _voice_table(), gr.update()
+        ok = voice_lib.delete(name)
+        msg = f"✅ Voice '{name}' deleted." if ok else f"⚠️ Voice '{name}' not found."
+        new_choices = _voice_choices()
+        return msg, _voice_table(), gr.update(choices=new_choices, value=_UPLOAD_SENTINEL)
+
+    def _voice_table():
+        voices = voice_lib.list_voices()
+        rows = []
+        for v in voices:
+            preview = v["ref_text"]
+            if len(preview) > 70:
+                preview = preview[:70] + "…"
+            rows.append([v["name"], preview])
+        return rows
+
+    def _lib_refresh():
+        """Refresh both the library table and the clone-tab saved-voice dropdown."""
+        new_choices = _voice_choices()
+        table = _voice_table()
+        return (
+            gr.update(choices=new_choices),   # clone-tab saved-voice dd
+            gr.update(choices=new_choices[1:]),  # lib-tab delete dd
+            table,
+        )
+
+    # ------------------------------------------------------------------
+    # CSS / Theme
+    # ------------------------------------------------------------------
+    theme = gr.themes.Soft(font=["Inter", "Arial", "sans-serif"])
     css = """
-    .gradio-container {max-width: 100% !important; font-size: 16px !important;}
-    .gradio-container h1 {font-size: 1.5em !important;}
-    .gradio-container .prose {font-size: 1.1em !important;}
-    .compact-audio audio {height: 60px !important;}
-    .compact-audio .waveform {min-height: 80px !important;}
+    .gradio-container { max-width: 100% !important; font-size: 16px !important; }
+    .gradio-container h1 { font-size: 1.5em !important; }
+    .gradio-container .prose { font-size: 1.1em !important; }
+    .compact-audio audio { height: 60px !important; }
+    .compact-audio .waveform { min-height: 80px !important; }
+    .lib-table { font-size: 0.9em; }
+    .status-box textarea { font-size: 0.95em; color: #444; }
+    .voice-badge {
+        display: inline-block; background: #e8f4ff; border-radius: 6px;
+        padding: 2px 10px; margin: 2px; font-size: 0.85em; color: #2060c0;
+    }
     """
 
-    # Reusable: language dropdown component
     def _lang_dropdown(label="Language (optional) / 语种 (可选)", value="Auto"):
         return gr.Dropdown(
             label=label,
@@ -242,170 +431,154 @@ def build_demo(
             info="Keep as Auto to auto-detect the language.",
         )
 
-    # Reusable: optional generation settings accordion
-    def _gen_settings():
-        with gr.Accordion("Generation Settings (optional)", open=False):
-            sp = gr.Slider(
-                0.5,
-                1.5,
-                value=1.0,
-                step=0.05,
-                label="Speed",
-                info="1.0 = normal. >1 faster, <1 slower. Ignored if Duration is set.",
-            )
-            du = gr.Number(
-                value=None,
-                label="Duration (seconds)",
-                info=(
-                    "Leave empty to use speed."
-                    " Set a fixed duration to override speed."
-                ),
-            )
-            ns = gr.Slider(
-                4,
-                64,
-                value=32,
-                step=1,
-                label="Inference Steps",
-                info="Default: 32. Lower = faster, higher = better quality.",
-            )
-            dn = gr.Checkbox(
-                label="Denoise",
-                value=True,
-                info="Default: enabled. Uncheck to disable denoising.",
-            )
-            gs = gr.Slider(
-                0.0,
-                4.0,
-                value=2.0,
-                step=0.1,
-                label="Guidance Scale (CFG)",
-                info="Default: 2.0.",
-            )
-            pp = gr.Checkbox(
-                label="Preprocess Prompt",
-                value=True,
-                info="apply silence removal and trimming to the reference "
-                "audio, add punctuation in the end of reference text (if not already)",
-            )
-            po = gr.Checkbox(
-                label="Postprocess Output",
-                value=True,
-                info="Remove long silences from generated audio.",
-            )
-        return ns, gs, dn, sp, du, pp, po
-
+    # ==================================================================
+    # Build Gradio blocks
+    # ==================================================================
     with gr.Blocks(theme=theme, css=css, title="OmniVoice Demo") as demo:
+
         gr.Markdown(
             """
-# OmniVoice Demo
+# 🎙️ OmniVoice Demo
 
-State-of-the-art text-to-speech model for **600+ languages**, supporting:
+State-of-the-art text-to-speech for **600+ languages** — voice cloning, voice design,
+and a **persistent voice library** for instant reuse of saved voice profiles.
 
-- **Voice Clone** — Clone any voice from a reference audio
-- **Voice Design** — Create custom voices with speaker attributes
-
-Built with [OmniVoice](https://github.com/k2-fsa/OmniVoice)
-by Xiaomi AI Lab Next-gen Kaldi team.
+Built with [OmniVoice](https://github.com/k2-fsa/OmniVoice) by Xiaomi AI Lab Next-gen Kaldi team.
 """
         )
 
         with gr.Tabs():
+
             # ==============================================================
-            # Voice Clone
+            # TAB 1 — Voice Clone (with streaming + saved-voice selector)
             # ==============================================================
-            with gr.TabItem("Voice Clone"):
+            with gr.TabItem("🎤 Voice Clone"):
                 with gr.Row():
+                    # ---- Left column: inputs ----
                     with gr.Column(scale=1):
+
                         vc_text = gr.Textbox(
-                            label="Text to Synthesize / 待合成文本",
+                            label="Text to Synthesise / Текст для синтеза",
                             lines=4,
-                            placeholder="Enter the text you want to synthesize...",
+                            placeholder="Enter the text you want to synthesise…",
                         )
-                        vc_ref_audio = gr.Audio(
-                            label="Reference Audio / 参考音频",
-                            type="filepath",
-                            elem_classes="compact-audio",
+
+                        # --- Saved voice selector ---
+                        vc_saved = gr.Dropdown(
+                            label="Saved Voice / Сохранённый голос",
+                            choices=_voice_choices(),
+                            value=_UPLOAD_SENTINEL,
+                            interactive=True,
+                            info=(
+                                "Select a pre-cloned voice from the library, "
+                                "or keep '── Upload audio ──' to use the fields below."
+                            ),
                         )
-                        gr.Markdown(
-                            "<span style='font-size:0.85em;color:#888;'>"
-                            "Recommended: 3–10 seconds audio. "
-                            "</span>"
-                        )
-                        vc_ref_text = gr.Textbox(
-                            label=("Reference Text (optional)" " / 参考音频文本（可选）"),
-                            lines=2,
-                            placeholder="Transcript of the reference audio. Leave empty"
-                            " to auto-transcribe via ASR models.",
-                        )
-                        vc_lang = _lang_dropdown("Language (optional) / 语种 (可选)")
+
+                        # --- Upload-audio group (hidden when a saved voice is chosen) ---
+                        with gr.Group() as vc_upload_group:
+                            vc_ref_audio = gr.Audio(
+                                label="Reference Audio / Референсное аудио",
+                                type="filepath",
+                                elem_classes="compact-audio",
+                            )
+                            gr.Markdown(
+                                "<span style='font-size:0.85em;color:#888;'>"
+                                "Recommended: 3–10 seconds of clear speech."
+                                "</span>"
+                            )
+                            vc_ref_text = gr.Textbox(
+                                label="Reference Text (optional) / Текст референса (необяз.)",
+                                lines=2,
+                                placeholder=(
+                                    "Transcript of the reference audio. "
+                                    "Leave empty to auto-transcribe via ASR."
+                                ),
+                            )
+
+                        vc_lang = _lang_dropdown()
+
                         with gr.Accordion("Instruct (optional)", open=False):
                             vc_instruct = gr.Textbox(label="Instruct", lines=2)
-                        (
-                            vc_ns,
-                            vc_gs,
-                            vc_dn,
-                            vc_sp,
-                            vc_du,
-                            vc_pp,
-                            vc_po,
-                        ) = _gen_settings()
-                        vc_btn = gr.Button("Generate / 生成", variant="primary")
+
+                        vc_ns, vc_gs, vc_dn, vc_sp, vc_du, vc_pp, vc_po = _gen_settings()
+
+                        vc_btn = gr.Button("▶ Generate / Сгенерировать", variant="primary")
+
+                        # --- Quick "save this audio as a voice" panel ---
+                        with gr.Accordion(
+                            "💾 Clone & Save to Library / Клонировать и сохранить", open=False
+                        ):
+                            gr.Markdown(
+                                "Clone the **uploaded** reference audio and save it under "
+                                "a name for instant reuse later."
+                            )
+                            vc_save_name = gr.Textbox(
+                                label="Voice Name / Имя голоса",
+                                placeholder="e.g. Alice, Speaker1…",
+                            )
+                            vc_save_btn = gr.Button(
+                                "📌 Save Voice / Сохранить голос", variant="secondary"
+                            )
+                            vc_save_status = gr.Textbox(
+                                label="Save Status / Статус сохранения",
+                                interactive=False,
+                                elem_classes="status-box",
+                            )
+
+                    # ---- Right column: outputs ----
                     with gr.Column(scale=1):
                         vc_audio = gr.Audio(
-                            label="Output Audio / 合成结果",
+                            label="Output Audio / Результат",
                             type="numpy",
                         )
-                        vc_status = gr.Textbox(label="Status / 状态", lines=2)
+                        vc_status = gr.Textbox(
+                            label="Status / Статус",
+                            lines=2,
+                            interactive=False,
+                            elem_classes="status-box",
+                        )
 
-                def _clone_fn(
-                    text, lang, ref_aud, ref_text, instruct, ns, gs, dn, sp, du, pp, po
-                ):
-                    return _gen(
-                        text,
-                        lang,
-                        ref_aud,
-                        instruct,
-                        ns,
-                        gs,
-                        dn,
-                        sp,
-                        du,
-                        pp,
-                        po,
-                        mode="clone",
-                        ref_text=ref_text or None,
-                    )
+                # Toggle upload group visibility
+                def _toggle_upload(saved):
+                    show = saved == _UPLOAD_SENTINEL
+                    return gr.update(visible=show)
 
+                vc_saved.change(_toggle_upload, inputs=[vc_saved], outputs=[vc_upload_group])
+
+                # Generate (streaming)
                 vc_btn.click(
-                    _clone_fn,
+                    _clone_streaming,
                     inputs=[
-                        vc_text,
-                        vc_lang,
-                        vc_ref_audio,
-                        vc_ref_text,
-                        vc_instruct,
-                        vc_ns,
-                        vc_gs,
-                        vc_dn,
-                        vc_sp,
-                        vc_du,
-                        vc_pp,
-                        vc_po,
+                        vc_text, vc_lang, vc_saved, vc_ref_audio, vc_ref_text,
+                        vc_instruct, vc_ns, vc_gs, vc_dn, vc_sp, vc_du, vc_pp, vc_po,
                     ],
                     outputs=[vc_audio, vc_status],
                 )
 
+                # Quick-save from Voice Clone tab (uses the same _lib_save returning 4 values)
+                def _quick_save(name, ref_aud, ref_text, pp_flag):
+                    status, _table, vc_saved_upd, _del_upd = _lib_save(
+                        name, ref_aud, ref_text, pp_flag
+                    )
+                    return status, vc_saved_upd
+
+                vc_save_btn.click(
+                    _quick_save,
+                    inputs=[vc_save_name, vc_ref_audio, vc_ref_text, vc_pp],
+                    outputs=[vc_save_status, vc_saved],
+                )
+
             # ==============================================================
-            # Voice Design
+            # TAB 2 — Voice Design (unchanged logic, no streaming needed)
             # ==============================================================
-            with gr.TabItem("Voice Design"):
+            with gr.TabItem("🎨 Voice Design"):
                 with gr.Row():
                     with gr.Column(scale=1):
                         vd_text = gr.Textbox(
-                            label="Text to Synthesize / 待合成文本",
+                            label="Text to Synthesise / Текст для синтеза",
                             lines=4,
-                            placeholder="Enter the text you want to synthesize...",
+                            placeholder="Enter the text you want to synthesise…",
                         )
                         vd_lang = _lang_dropdown()
 
@@ -421,76 +594,138 @@ by Xiaomi AI Lab Next-gen Kaldi team.
                                 )
                             )
 
-                        (
-                            vd_ns,
-                            vd_gs,
-                            vd_dn,
-                            vd_sp,
-                            vd_du,
-                            vd_pp,
-                            vd_po,
-                        ) = _gen_settings()
-                        vd_btn = gr.Button("Generate / 生成", variant="primary")
+                        vd_ns, vd_gs, vd_dn, vd_sp, vd_du, vd_pp, vd_po = _gen_settings()
+                        vd_btn = gr.Button("▶ Generate / Сгенерировать", variant="primary")
+
                     with gr.Column(scale=1):
                         vd_audio = gr.Audio(
-                            label="Output Audio / 合成结果",
+                            label="Output Audio / Результат",
                             type="numpy",
                         )
-                        vd_status = gr.Textbox(label="Status / 状态", lines=2)
-
-                def _build_instruct(groups):
-                    """Extract instruct text from UI dropdowns.
-
-                    Language unification and validation is handled by
-                    _resolve_instruct inside _preprocess_all.
-                    """
-                    selected = [g for g in groups if g and g != "Auto"]
-                    if not selected:
-                        return None
-                    parts = []
-                    for v in selected:
-                        if " / " in v:
-                            en, zh = v.split(" / ", 1)
-                            # Dialects have no English equivalent
-                            if "Dialect" in v.split(" / ")[0]:
-                                parts.append(zh.strip())
-                            else:
-                                parts.append(en.strip())
-                        else:
-                            parts.append(v)
-                    return ", ".join(parts)
-
-                def _design_fn(text, lang, ns, gs, dn, sp, du, pp, po, *groups):
-                    return _gen(
-                        text,
-                        lang,
-                        None,
-                        _build_instruct(groups),
-                        ns,
-                        gs,
-                        dn,
-                        sp,
-                        du,
-                        pp,
-                        po,
-                        mode="design",
-                    )
+                        vd_status = gr.Textbox(
+                            label="Status / Статус",
+                            lines=2,
+                            interactive=False,
+                            elem_classes="status-box",
+                        )
 
                 vd_btn.click(
                     _design_fn,
                     inputs=[
-                        vd_text,
-                        vd_lang,
-                        vd_ns,
-                        vd_gs,
-                        vd_dn,
-                        vd_sp,
-                        vd_du,
-                        vd_pp,
-                        vd_po,
-                    ]
-                    + vd_groups,
+                        vd_text, vd_lang, vd_ns, vd_gs, vd_dn, vd_sp, vd_du, vd_pp, vd_po,
+                    ] + vd_groups,
                     outputs=[vd_audio, vd_status],
+                )
+
+            # ==============================================================
+            # TAB 3 — Voice Library
+            # ==============================================================
+            with gr.TabItem("📚 Voice Library / Библиотека голосов"):
+
+                gr.Markdown(
+                    "Pre-clone any reference audio, give it a name, and reuse it "
+                    "instantly from the **Voice Clone** tab — no re-uploading needed."
+                )
+
+                with gr.Row():
+                    # ---- Left: add a new voice ----
+                    with gr.Column(scale=1):
+                        gr.Markdown("### ➕ Add / Clone New Voice")
+                        lib_name = gr.Textbox(
+                            label="Voice Name / Имя голоса",
+                            placeholder="e.g. Alice, CEO, Narrator…",
+                        )
+                        lib_ref_audio = gr.Audio(
+                            label="Reference Audio / Референсное аудио",
+                            type="filepath",
+                            elem_classes="compact-audio",
+                        )
+                        gr.Markdown(
+                            "<span style='font-size:0.85em;color:#888;'>"
+                            "3–10 seconds recommended for best cloning quality."
+                            "</span>"
+                        )
+                        lib_ref_text = gr.Textbox(
+                            label="Reference Text (optional) / Текст референса (необяз.)",
+                            lines=2,
+                            placeholder=(
+                                "Transcript of the audio. "
+                                "Leave empty to auto-transcribe."
+                            ),
+                        )
+                        lib_preprocess = gr.Checkbox(
+                            label="Preprocess Audio / Предобработать аудио",
+                            value=True,
+                            info="Trim silences and normalise volume before cloning.",
+                        )
+                        lib_save_btn = gr.Button(
+                            "🧬 Clone & Save / Клонировать и сохранить",
+                            variant="primary",
+                        )
+                        lib_save_status = gr.Textbox(
+                            label="Status / Статус",
+                            interactive=False,
+                            lines=2,
+                            elem_classes="status-box",
+                        )
+
+                    # ---- Right: manage saved voices ----
+                    with gr.Column(scale=1):
+                        gr.Markdown("### 🗂️ Saved Voices / Сохранённые голоса")
+
+                        lib_refresh_btn = gr.Button("🔄 Refresh / Обновить")
+
+                        lib_table = gr.Dataframe(
+                            headers=["Name / Имя", "Reference Text Preview"],
+                            value=_voice_table(),
+                            label="",
+                            interactive=False,
+                            elem_classes="lib-table",
+                            wrap=True,
+                        )
+
+                        gr.Markdown("---")
+                        gr.Markdown("#### 🗑️ Delete a Voice / Удалить голос")
+
+                        lib_del_dd = gr.Dropdown(
+                            label="Select Voice to Delete / Выбрать голос для удаления",
+                            choices=voice_lib.names(),
+                            value=None,
+                            interactive=True,
+                        )
+                        lib_del_btn = gr.Button(
+                            "🗑️ Delete / Удалить", variant="stop"
+                        )
+                        lib_del_status = gr.Textbox(
+                            label="Delete Status / Статус удаления",
+                            interactive=False,
+                            elem_classes="status-box",
+                        )
+
+                # Wiring: save (returns status + table + updated dropdowns in both tabs)
+                lib_save_btn.click(
+                    _lib_save,
+                    inputs=[lib_name, lib_ref_audio, lib_ref_text, lib_preprocess],
+                    outputs=[lib_save_status, lib_table, vc_saved, lib_del_dd],
+                )
+
+                # Wiring: delete (returns status + table + updated delete dropdown)
+                lib_del_btn.click(
+                    _lib_delete,
+                    inputs=[lib_del_dd],
+                    outputs=[lib_del_status, lib_table, lib_del_dd],
+                ).then(
+                    # Also refresh the clone-tab saved-voice dropdown
+                    lambda: gr.update(choices=_voice_choices(), value=_UPLOAD_SENTINEL),
+                    inputs=[],
+                    outputs=[vc_saved],
+                )
+
+                # Wiring: refresh all dropdowns + table
+                lib_refresh_btn.click(
+                    _lib_refresh,
+                    inputs=[],
+                    outputs=[vc_saved, lib_del_dd, lib_table],
                 )
 
     return demo
@@ -515,7 +750,8 @@ def main(argv=None) -> int:
     if not checkpoint:
         parser.print_help()
         return 0
-    logging.info(f"Loading model from {checkpoint}, device={device} ...")
+
+    logging.info("Loading model from %s on device=%s …", checkpoint, device)
     model = OmniVoice.from_pretrained(
         checkpoint,
         device_map=device,
@@ -523,9 +759,13 @@ def main(argv=None) -> int:
         load_asr=not args.no_asr,
         asr_model_name=args.asr_model,
     )
-    print("Model loaded.")
+    logging.info("Model loaded.")
 
-    demo = build_demo(model, checkpoint)
+    demo = build_demo(
+        model,
+        checkpoint,
+        library_dir=args.library_dir,
+    )
 
     demo.queue().launch(
         server_name=args.ip,

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -600,6 +600,171 @@ class OmniVoice(PreTrainedModel):
 
         return generated_audios
 
+    @torch.inference_mode()
+    def generate_streaming(
+        self,
+        text: str,
+        language: Optional[str] = None,
+        ref_text: Optional[str] = None,
+        ref_audio=None,
+        voice_clone_prompt: Optional["VoiceClonePrompt"] = None,
+        instruct: Optional[str] = None,
+        duration: Optional[float] = None,
+        speed: Optional[float] = None,
+        generation_config: Optional["OmniVoiceGenerationConfig"] = None,
+        **kwargs,
+    ):
+        """Streaming TTS generator for a single text input.
+
+        Yields ``(audio_1d_array, status_str)`` tuples as generation progresses:
+
+        - **Short texts** (below ``audio_chunk_threshold``): yields once with
+          the complete audio and status ``"Done."``.
+        - **Long texts**: yields after *each chunk* with cumulative audio,
+          enabling progressive playback in the UI.
+
+        Args:
+            text: A single string to synthesise (batch not supported here).
+            language: Language name or ID; ``None`` for auto-detection.
+            ref_text: Optional transcript of *ref_audio*.
+            ref_audio: Optional reference audio — file path or ``(waveform, sr)``.
+            voice_clone_prompt: Pre-computed prompt (overrides *ref_audio*).
+            instruct: Voice-design instruction string.
+            duration: Fixed output duration in seconds.
+            speed: Speaking speed factor (``>1`` faster, ``<1`` slower).
+            generation_config: Explicit config; overrides ``**kwargs``.
+            **kwargs: Fields forwarded to :class:`OmniVoiceGenerationConfig`.
+
+        Yields:
+            ``(np.ndarray, str)`` — 1-D float32 waveform at 24 kHz and a
+            human-readable status message.
+        """
+        if self.audio_tokenizer is None or self.text_tokenizer is None:
+            raise RuntimeError(
+                "Model not loaded with tokenizers. "
+                "Use OmniVoice.from_pretrained()."
+            )
+
+        gen_config = (
+            generation_config
+            if generation_config is not None
+            else OmniVoiceGenerationConfig.from_dict(kwargs)
+        )
+        self.eval()
+
+        full_task = self._preprocess_all(
+            text=text,
+            language=language,
+            ref_text=ref_text,
+            ref_audio=ref_audio,
+            voice_clone_prompt=voice_clone_prompt,
+            instruct=instruct,
+            preprocess_prompt=gen_config.preprocess_prompt,
+            speed=speed,
+            duration=duration,
+        )
+
+        ref_rms = full_task.ref_rms[0]
+        short_idx, long_idx = full_task.get_indices(
+            gen_config, self.audio_tokenizer.config.frame_rate
+        )
+
+        # ----------------------------------------------------------------
+        # SHORT TEXT — single iterative pass, yield once when done
+        # ----------------------------------------------------------------
+        if short_idx:
+            tokens = self._generate_iterative(full_task, gen_config)[0]
+            audio = self._decode_and_post_process(tokens, ref_rms, gen_config)
+            yield audio, "Done."
+            return
+
+        # ----------------------------------------------------------------
+        # LONG TEXT — chunk-by-chunk streaming
+        # ----------------------------------------------------------------
+        task = full_task
+        avg_tokens_per_char = task.target_lens[0] / max(1, len(task.texts[0]))
+        frame_rate = self.audio_tokenizer.config.frame_rate
+        text_chunk_len = int(
+            gen_config.audio_chunk_duration * frame_rate / avg_tokens_per_char
+        )
+        chunks = chunk_text_punctuation(
+            text=task.texts[0],
+            chunk_len=text_chunk_len,
+            min_chunk_len=3,
+        )
+        total = len(chunks)
+        has_ref = task.ref_audio_tokens[0] is not None
+        tokenizer_device = self.audio_tokenizer.device
+
+        collected_raw: list = []   # raw (1, T) chunk waveforms for cross-fade
+        first_chunk_tokens = None  # used as reference for no-ref subsequent chunks
+
+        for ci, chunk_text in enumerate(chunks):
+            # Determine reference audio/text for this chunk
+            if has_ref:
+                ref_audio_for_chunk = task.ref_audio_tokens[0]
+                ref_text_for_chunk = task.ref_texts[0]
+            else:
+                if ci == 0:
+                    ref_audio_for_chunk = None
+                    ref_text_for_chunk = None
+                else:
+                    # Use the first generated chunk as a consistent voice reference
+                    ref_audio_for_chunk = first_chunk_tokens
+                    ref_text_for_chunk = chunks[0]
+
+            chunk_target_len = self._estimate_target_tokens(
+                chunk_text,
+                ref_text_for_chunk,
+                ref_audio_for_chunk.size(-1) if ref_audio_for_chunk is not None else None,
+                speed=task.speed[0] if task.speed else 1.0,
+            )
+
+            sub_task = GenerationTask(
+                batch_size=1,
+                texts=[chunk_text],
+                target_lens=[chunk_target_len],
+                langs=[task.langs[0]],
+                instructs=[task.instructs[0]],
+                ref_texts=[ref_text_for_chunk],
+                ref_audio_tokens=[ref_audio_for_chunk],
+                ref_rms=[ref_rms],
+                speed=[task.speed[0]] if task.speed else None,
+            )
+
+            chunk_token = self._generate_iterative(sub_task, gen_config)[0]
+
+            # Store first chunk tokens for no-ref mode consistency
+            if ci == 0 and not has_ref:
+                first_chunk_tokens = chunk_token
+
+            # Decode chunk to raw waveform (shape: 1, T)
+            chunk_raw = (
+                self.audio_tokenizer.decode(
+                    chunk_token.to(tokenizer_device).unsqueeze(0)
+                )
+                .audio_values[0]
+                .cpu()
+                .numpy()
+            )
+            collected_raw.append(chunk_raw)
+
+            # Build cumulative audio: cross-fade on final chunk, concat otherwise
+            is_last = ci == total - 1
+            if is_last:
+                combined = cross_fade_chunks(collected_raw, self.sampling_rate)
+            else:
+                combined = np.concatenate(collected_raw, axis=-1)
+
+            processed = self._post_process_audio(
+                combined,
+                postprocess_output=gen_config.postprocess_output,
+                ref_rms=ref_rms,
+            ).squeeze(0)
+
+            status = "Done." if is_last else f"Generating... chunk {ci + 1}/{total}"
+            yield processed, status
+
     def create_voice_clone_prompt(
         self,
         ref_audio: Union[str, tuple[torch.Tensor, int]],

--- a/omnivoice/utils/voice_library.py
+++ b/omnivoice/utils/voice_library.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors:  Han Zhu)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Persistent named voice-clone library.
+
+Saves ``VoiceClonePrompt`` objects to disk so you can:
+- Clone a voice once and reuse it without re-uploading reference audio.
+- Give meaningful names to saved clones.
+- Load / delete / list clones programmatically or from the Gradio UI.
+
+Storage layout (each voice = two files)::
+
+    <library_dir>/
+        my_voice.json    <- metadata: display name, ref_text, ref_rms
+        my_voice.pt      <- serialised ref_audio_tokens tensor  (C, T)
+
+Example::
+
+    from omnivoice import OmniVoice
+    from omnivoice.utils.voice_library import VoiceLibrary
+
+    model = OmniVoice.from_pretrained("k2-fsa/OmniVoice", ...)
+    lib   = VoiceLibrary()                        # default: ~/.omnivoice/voices/
+
+    # Clone once and persist
+    prompt = model.create_voice_clone_prompt("speaker.wav")
+    lib.save("Alice", prompt)
+
+    # Reuse later — no audio file needed
+    prompt = lib.load("Alice")
+    audio  = model.generate("Hello world", voice_clone_prompt=prompt)
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import torch
+
+if TYPE_CHECKING:
+    from omnivoice.models.omnivoice import VoiceClonePrompt
+
+# Default storage directory (~/.omnivoice/voices/ — cross-platform)
+DEFAULT_LIBRARY_DIR: Path = Path.home() / ".omnivoice" / "voices"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_stem(name: str) -> str:
+    """Convert a display name to a filesystem-safe file stem (max 80 chars)."""
+    stem = re.sub(r"[^\w\-.]", "_", name.strip())
+    stem = re.sub(r"_+", "_", stem).strip("_.")
+    return (stem or "voice")[:80]
+
+
+# ---------------------------------------------------------------------------
+# VoiceLibrary
+# ---------------------------------------------------------------------------
+
+
+class VoiceLibrary:
+    """Persistent library of named VoiceClonePrompt objects.
+
+    Args:
+        library_dir: Directory where voices are stored.
+            Defaults to ``~/.omnivoice/voices/``.
+    """
+
+    def __init__(self, library_dir: Optional[str] = None):
+        self.library_dir = Path(library_dir or DEFAULT_LIBRARY_DIR)
+        self.library_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def save(self, name: str, prompt: "VoiceClonePrompt") -> None:
+        """Save *prompt* under the given display *name*.
+
+        Overwrites silently if a voice with this name already exists.
+
+        Args:
+            name: Human-readable display name (e.g. ``"Alice"``).
+            prompt: The VoiceClonePrompt to persist.
+
+        Raises:
+            ValueError: If *name* is empty.
+        """
+        name = name.strip()
+        if not name:
+            raise ValueError("Voice name must not be empty.")
+
+        safe = _safe_stem(name)
+        torch.save(prompt.ref_audio_tokens, self.library_dir / f"{safe}.pt")
+        meta: Dict = {
+            "name": name,
+            "safe_name": safe,
+            "ref_text": prompt.ref_text,
+            "ref_rms": float(prompt.ref_rms),
+        }
+        (self.library_dir / f"{safe}.json").write_text(
+            json.dumps(meta, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def load(self, name: str) -> "VoiceClonePrompt":
+        """Load a saved voice clone by display name.
+
+        Args:
+            name: The display name used in :meth:`save`.
+
+        Returns:
+            VoiceClonePrompt ready to pass to ``model.generate()``.
+
+        Raises:
+            KeyError: If no voice with this name is found.
+        """
+        from omnivoice.models.omnivoice import VoiceClonePrompt  # avoid circular import
+
+        meta, safe = self._find(name)
+        tokens = torch.load(self.library_dir / f"{safe}.pt", weights_only=True)
+        return VoiceClonePrompt(
+            ref_audio_tokens=tokens,
+            ref_text=meta["ref_text"],
+            ref_rms=float(meta["ref_rms"]),
+        )
+
+    def delete(self, name: str) -> bool:
+        """Delete a saved voice clone.
+
+        Args:
+            name: Display name of the voice to delete.
+
+        Returns:
+            ``True`` if found and deleted, ``False`` if not found.
+        """
+        try:
+            meta, safe = self._find(name)
+        except KeyError:
+            return False
+        (self.library_dir / f"{safe}.json").unlink(missing_ok=True)
+        (self.library_dir / f"{safe}.pt").unlink(missing_ok=True)
+        return True
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        """Rename a saved voice clone.
+
+        Args:
+            old_name: Current display name.
+            new_name: New display name.
+
+        Raises:
+            KeyError: If *old_name* is not found.
+        """
+        prompt = self.load(old_name)
+        self.delete(old_name)
+        self.save(new_name, prompt)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def list_voices(self) -> List[Dict]:
+        """Return sorted metadata dicts for all saved voices.
+
+        Each dict contains: ``name``, ``safe_name``, ``ref_text``, ``ref_rms``.
+        """
+        voices: List[Dict] = []
+        for path in sorted(self.library_dir.glob("*.json")):
+            try:
+                voices.append(json.loads(path.read_text(encoding="utf-8")))
+            except Exception:
+                pass
+        return voices
+
+    def names(self) -> List[str]:
+        """Return display names of all saved voices (alphabetically sorted)."""
+        return [v["name"] for v in self.list_voices()]
+
+    def exists(self, name: str) -> bool:
+        """Return ``True`` if a voice with this display name exists."""
+        try:
+            self._find(name)
+            return True
+        except KeyError:
+            return False
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _find(self, name: str) -> Tuple[Dict, str]:
+        """Locate metadata by display name.  Returns ``(meta, safe_stem)``."""
+        # Fast path: safe stem derived from name exists and name matches
+        safe = _safe_stem(name)
+        path = self.library_dir / f"{safe}.json"
+        if path.exists():
+            meta = json.loads(path.read_text(encoding="utf-8"))
+            if meta.get("name") == name:
+                return meta, safe
+
+        # Slow path: linear scan (handles name collisions on safe stems)
+        for meta in self.list_voices():
+            if meta.get("name") == name:
+                return meta, meta["safe_name"]
+
+        raise KeyError(f"Voice '{name}' not found in library at {self.library_dir}.")
+
+    def __repr__(self) -> str:
+        ns = self.names()
+        return f"VoiceLibrary(dir={self.library_dir!r}, voices={len(ns)}: {ns})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ dependencies = [
 
 [project.optional-dependencies]
 
+api = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.29.0",
+    "python-multipart>=0.0.9",   # multipart/form-data for file uploads
+]
+
 eval = [
     "jiwer==3.1.0",       # WER
     "s3prl",               # Speech representation (HuBERT etc.)
@@ -58,6 +64,7 @@ eval = [
 omnivoice-infer = "omnivoice.cli.infer:main"
 omnivoice-infer-batch = "omnivoice.cli.infer_batch:main"
 omnivoice-demo = "omnivoice.cli.demo:main"
+omnivoice-api = "omnivoice.api.server:main"
 
 [project.urls]
 Homepage = "https://github.com/k2-fsa/OmniVoice"


### PR DESCRIPTION
- Add `VoiceLibrary` class (omnivoice/utils/voice_library.py): pre-clone a voice once, save it by name to disk (~/.omnivoice/voices/), and reuse instantly without re-uploading reference audio.

- Add `OmniVoice.generate_streaming()` method: generator that yields (audio_1d, status) tuples as each chunk is decoded, enabling progressive playback in the UI for long texts. Short texts still complete in a single pass.

- Rewrite Gradio demo (omnivoice/cli/demo.py) with three tabs:
  * Voice Clone — saved-voice dropdown, streaming output, quick-save panel.
  * Voice Design — unchanged.
  * Voice Library — clone & name any audio, manage (list/delete) saved voices; changes propagate live to all dropdowns.

- Export `VoiceClonePrompt` and `VoiceLibrary` from omnivoice/__init__.py.