### PR TITLE
Skip fade and pad when postprocess_output is disabled

### DIFF
--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -757,7 +757,8 @@ class OmniVoice(PreTrainedModel):
 
         Args:
             generated_audio: Numpy array of shape (1, T).
-            postprocess_output: If True, remove long silences and apply fade/pad.
+            postprocess_output: If True, apply all post-processing, including
+                silence removal, fade-in/out, and silence padding.
             ref_rms: RMS of the reference audio for volume normalisation.
         Returns:
             Processed numpy array of shape (1, T).
@@ -778,10 +779,11 @@ class OmniVoice(PreTrainedModel):
             if peak > 1e-6:
                 generated_audio = generated_audio / peak * 0.5
 
-        generated_audio = fade_and_pad_audio(
-            generated_audio,
-            sample_rate=self.sampling_rate,
-        )
+        if postprocess_output:
+            generated_audio = fade_and_pad_audio(
+                generated_audio,
+                sample_rate=self.sampling_rate,
+            )
         return generated_audio
 
     def _generate_chunked(


### PR DESCRIPTION
## Summary

When `postprocess_output=False`, this PR makes sure that all audio post-processing is skipped.

## Changes

* Include `fade_and_pad_audio()` in the current `if postprocess_output:` condition.
* Modify the docstring to make it clear that all post-processing operations, such as fade-in/out, silence padding, and silence removal, are managed by `postprocess_output`.

## Inspiration

In the past, even when `postprocess_output=False`, `fade_and_pad_audio()` was always used. Consequently, silence removal was skipped when post-processing was disabled, although fade-in/out and silent padding were still applied.

This modification maintains the current default behavior (`postprocess_output=True`) while making the behavior consistent.

Fixes #194