### PR TITLE
Make flex_attention honor autocast (fixes silent fp32 attention, ~4x training slowdown)

### DIFF
--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -57,6 +57,7 @@ from transformers import (
     PreTrainedModel,
 )
 from transformers.modeling_outputs import ModelOutput
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, AttentionInterface
 from transformers.models.auto import CONFIG_MAPPING, AutoConfig
 
 from omnivoice.utils.audio import (
@@ -80,6 +81,31 @@ from omnivoice.utils.voice_design import (
 )
 
 logger = logging.getLogger(__name__)
+
+_AUTOCAST_FLEX_ATTENTION = "omnivoice_flex_attention"
+
+
+def _autocast_flex_attention(module, query, key, value, *args, **kwargs):
+    """flex_attention with the same autocast treatment SDPA already gets.
+
+    Mixed-precision training keeps fp32 master weights, so Qwen3's
+    ``q_norm``/``k_norm`` (fp32 weight x bf16 activation) silently promote
+    q/k — and, through the fp32 RoPE constants, v — back to fp32. SDPA is
+    on autocast's cast list and is downcast at the kernel boundary;
+    ``flex_attention`` is not, so with ``attn_implementation:
+    "flex_attention"`` all attention math runs in fp32: the fp32 backward
+    template is ~12x slower at head_dim=128 (61.8ms vs 5.1ms per
+    layer-call, H100, identical mask/shape/layout), and the flex and sdpa
+    paths become numerically inconsistent with each other. Casting here
+    restores the treatment autocast applies to every other matmul; softmax
+    accumulation inside the kernel is fp32 either way.
+    """
+    if torch.is_autocast_enabled(query.device.type) and query.dtype == torch.float32:
+        dtype = torch.get_autocast_dtype(query.device.type)
+        query, key, value = (t.to(dtype) for t in (query, key, value))
+    return ALL_ATTENTION_FUNCTIONS["flex_attention"](
+        module, query, key, value, *args, **kwargs
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +239,12 @@ class OmniVoice(PreTrainedModel):
         else:
             # Otherwise, initialize the LLM from the config.
             self.llm = AutoModel.from_config(self.config.llm_config)
+
+        if self.llm.config._attn_implementation == "flex_attention":
+            AttentionInterface.register(
+                _AUTOCAST_FLEX_ATTENTION, _autocast_flex_attention
+            )
+            self.llm.set_attn_implementation(_AUTOCAST_FLEX_ATTENTION)
 
         self.audio_embeddings = nn.Embedding(
             config.num_audio_codebook * config.audio_vocab_size,


### PR DESCRIPTION
## Summary

With the default training setup (mixed_precision: "bf16" + attn_implementation: "flex_attention"), the flex attention path can silently receive fp32 Q/K/V at the attention-kernel boundary and dispatch fp32 forward/backward kernels. On our H100 training setup this costs roughly 4× end-to-end throughput.

This PR restores bf16 flex attention in mixed precision with a 32-line repo-local change using Transformers' public AttentionInterface API.

## Mechanism
Accelerate bf16 mixed precision keeps model parameters in fp32.
In Qwen3 attention, per-head q_norm / k_norm can promote projected Q/K activations back to fp32.
scaled_dot_product_attention is covered by autocast, so the SDPA fallback path casts eligible attention inputs back to the active autocast dtype.
flex_attention is not covered in the same way in this stack, so fp32 inputs can pass through unchanged and dispatch fp32 flex kernels. As a result, the two attn_implementation paths can differ not only in backend but also in effective attention dtype.
At head_dim=128, the fp32 flex backward template is a register-pressure pathology: 61.8 ms vs 5.1 ms per layer-call on H100 with identical mask, shape, GQA layout, and gradient strides — about 12× at the kernel level and about 4× end-to-end.

## Fix

Register omnivoice_flex_attention via AttentionInterface.register. The registered implementation casts Q/K/V to the active autocast dtype at the flex-attention boundary when autocast is enabled and the inputs are still fp32.

This only controls the input dtype passed to the flex kernel; it does not force low-precision softmax accumulation. The behavior matches the intended mixed-precision boundary behavior of SDPA-style attention paths.

No global attention registry entries are modified. The change is a strict no-op when autocast is off or inputs are already low precision.
## Measured

Production fork of this repo, 0.6B Qwen3 backbone, packed 20480 tokens/GPU, H100:

| Metric | fp32 attention (current behavior) | bf16 cast (this PR) | Δ |
|---|---|---|---|
| flex backward kernel, per layer-call¹ | 61.8 ms | 5.1 ms | **12.1×** |
| training step time (3×H100) | 3.240 s/it | 0.755 s/it | **4.3×** |
| training throughput, tokens/s/GPU | 6,321 | 27,126 | 4.3× |
| MFU² | 3.3% | 14.3% | +11.0 pp |
| loss parity vs fp32 attention (300 steps, same seed) | — | worst-rel 0.43% | — |

¹ identical mask, shapes, GQA layout, and gradient strides; head_dim=128.
² model FLOPs from exact parameter census + real BlockMask visible-pair counts, against 989 TFLOPS dense bf16 peak.

We can attach a step-time timeline from a continuous production run crossing the fix boundary (same job/data/hardware before vs after) in a follow-up comment.

## Minimal repro

CPU-only, stock transformers ≥ 5.3 — shows fp32 arriving at the attention interface under bf16 autocast:

```python
import torch
from transformers import Qwen3Config, Qwen3Model
from transformers.modeling_utils import AttentionInterface

seen = {}
def probe(module, q, k, v, *a, **kw):
    seen["dtype"] = q.dtype
    return q.transpose(1, 2).contiguous(), None

AttentionInterface.register("probe", probe)
m = Qwen3Model(Qwen3Config(hidden_size=64, num_hidden_layers=1, num_attention_heads=4,
                           num_key_value_heads=2, head_dim=16, vocab_size=128))  # fp32 weights = master weights
m.set_attn_implementation("probe")
with torch.no_grad(), torch.autocast("cpu", dtype=torch.bfloat16):
    m(torch.randint(0, 128, (1, 8)))
print(seen["dtype"])  # torch.float32 — should be bfloat16
```

## Note

The root fix arguably belongs in PyTorch (`flex_attention` isn't in autocast's op coverage while SDPA is); this PR is the minimal repo-local correction until then.
