### PR TITLE
Avoid decoding the full reference audio just to get its duration

### DIFF
--- a/omnivoice/cli/infer_batch.py
+++ b/omnivoice/cli/infer_batch.py
@@ -247,6 +247,21 @@ def process_init(rank_queue, model_checkpoint, warmup=0):
     logging.info(f"Worker on {worker_device} initialized successfully.")
 
 
+def _get_audio_duration(audio_path: str) -> float:
+    """Return the duration of an audio file in seconds.
+
+    Reads only the file header, so the samples are never decoded or resampled.
+    Falls back to a full decode for formats ``soundfile`` cannot inspect
+    (e.g. MP3/M4A on older libsndfile builds).
+    """
+    try:
+        info = sf.info(audio_path)
+        return info.frames / info.samplerate
+    except Exception:
+        wav = load_audio(audio_path, SAMPLING_RATE)
+        return wav.shape[-1] / SAMPLING_RATE
+
+
 def estimate_sample_total_duration(
     duration_estimator: RuleDurationEstimator,
     text: str,
@@ -261,8 +276,7 @@ def estimate_sample_total_duration(
     duration contributes to the total.
     """
     if ref_audio_path is not None:
-        ref_wav = load_audio(ref_audio_path, SAMPLING_RATE)
-        ref_duration = ref_wav.shape[-1] / SAMPLING_RATE
+        ref_duration = _get_audio_duration(ref_audio_path)
     else:
         ref_duration = 0
 


### PR DESCRIPTION
## Problem

`estimate_sample_total_duration()` needs one number — the reference duration in seconds — but obtains it by decoding the entire audio file and resampling it:

```python
ref_wav = load_audio(ref_audio_path, SAMPLING_RATE)
ref_duration = ref_wav.shape[-1] / SAMPLING_RATE
```

The resample is redundant: duration in seconds does not change under resampling.

This matters more than it looks, because of *where* it runs. `_sort_samples_by_duration()` calls it once per sample in a plain serial loop, before any batch is submitted to the workers:

```python
for sample in samples:
    ...
    total_duration = estimate_sample_total_duration(...)
```

So the cost is `O(n)` on a single core, it happens before inference starts, and `--nj_per_gpu` cannot hide it. The GPU sits idle at 0% the whole time. In the common voice-cloning case, where every line shares one reference clip, the same file is decoded from scratch for every line.

I hit this with a 76k-line test list: ~46 minutes of a single core spinning before the first sample reached the GPU. It looks like a hang — the log stops after `Running batch inference` and nothing appears in `--res_dir`.

## Fix

Read the duration from the file header via `soundfile.info()`, which does not decode samples. Fall back to the previous full decode for formats `soundfile` cannot inspect (e.g. MP3/M4A on older libsndfile builds), so no input that worked before stops working.

`soundfile` is already imported in this module, so no new dependency.

## Verification

Same 7.4s FLAC reference, before and after:

```
before : 7.365000000 s
after  : 7.365000000 s
delta  : 0.00e+00 s
```

Timing (reference on a network filesystem, so this is a conservative measurement — on local disk `sf.info()` is faster still):

```
per call: 36.1 ms -> 2.9 ms   (12x)
```

Projected onto `_sort_samples_by_duration()`, which is the serial loop that runs before any GPU work:

| samples | before | after |
|---|---|---|
| 500 | 0.3 min | 0.02 min |
| 10,000 | 6.0 min | 0.49 min |
| 76,274 | 45.9 min | 3.71 min |

Generated audio is unaffected — this only changes how the duration used for batch clustering is obtained.
