### PR TITLE
Honor asr_model_name when the ASR model is loaded lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ audio = model.generate(
 ) # audio is a list of `np.ndarray` with shape (T,) at 24 kHz.
 
 # If you don't want to input `ref_text` manually, you can directly omit the `ref_text`.
-# The model will use Whisper ASR to auto-transcribe it.
+# The model will use Whisper ASR to auto-transcribe it. To use a local copy (or
+# a different Whisper model), pass `asr_model_name="..."` to `from_pretrained`.
 
 sf.write("out.wav", audio[0], 24000)
 ```

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -274,12 +274,13 @@ class OmniVoice(PreTrainedModel):
         self.duration_estimator = None
         self.sampling_rate = None
         self._asr_pipe = None
+        self._asr_model_name = "openai/whisper-large-v3-turbo"
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
         train_mode = kwargs.pop("train", False)
         load_asr = kwargs.pop("load_asr", False)
-        asr_model_name = kwargs.pop("asr_model_name", "openai/whisper-large-v3-turbo")
+        asr_model_name = kwargs.pop("asr_model_name", None)
 
         # Suppress noisy INFO logs from transformers/huggingface_hub during loading
         _prev_disable = logging.root.manager.disable
@@ -317,8 +318,10 @@ class OmniVoice(PreTrainedModel):
 
                 model.duration_estimator = RuleDurationEstimator()
 
+                if asr_model_name is not None:
+                    model._asr_model_name = asr_model_name
                 if load_asr:
-                    model.load_asr_model(model_name=asr_model_name)
+                    model.load_asr_model()
         finally:
             logging.disable(_prev_disable)
 
@@ -328,13 +331,19 @@ class OmniVoice(PreTrainedModel):
     # ASR support (optional, for auto-transcription)
     # -------------------------------------------------------------------
 
-    def load_asr_model(self, model_name: str = "openai/whisper-large-v3-turbo"):
+    def load_asr_model(self, model_name: Optional[str] = None):
         """Load a Whisper ASR model for reference audio transcription.
 
         Args:
-            model_name: HuggingFace model name or local path for the Whisper model.
+            model_name: HuggingFace model name or local path for the Whisper
+                model. Defaults to the ``asr_model_name`` passed to
+                :meth:`from_pretrained` (``openai/whisper-large-v3-turbo``
+                if unset).
         """
         from transformers import pipeline as hf_pipeline
+
+        if model_name is None:
+            model_name = self._asr_model_name
 
         logger.info("Loading ASR model %s ...", model_name)
         asr_dtype = (


### PR DESCRIPTION
## Problem

The `asr_model_name` argument of `OmniVoice.from_pretrained()` is silently discarded unless `load_asr=True` is also passed. When `ref_text` is omitted, `generate()` lazily loads the ASR model via `self.load_asr_model()` with no arguments, which always downloads the hardcoded `openai/whisper-large-v3-turbo` — even when the user configured a different (or local) Whisper model.

This is the remaining pain point of #175: a local path already works for the main model (and the audio tokenizer is bundled inside the model repo), but there was no way to control where the Whisper model comes from on the lazy-load path.

## Fix

Store the configured name on the instance and let `load_asr_model()` default to it:

- `__init__` initializes `self._asr_model_name = "openai/whisper-large-v3-turbo"` (the default now lives in a single place)
- `from_pretrained` records a user-supplied `asr_model_name` on the instance
- `load_asr_model(model_name=None)` falls back to the stored name, so both the lazy path in `generate()` and direct calls honor it

Behavior is unchanged for every existing call pattern, including `omnivoice-demo`'s `--asr-model` flag (its argparse default is the same string). The only change: `asr_model_name` is no longer ignored when `load_asr=False`.

## Reproduction

```python
import torch
from omnivoice import OmniVoice

model = OmniVoice.from_pretrained(
    "k2-fsa/OmniVoice",
    device_map="mps",  # same on cuda/cpu
    dtype=torch.float16,
    asr_model_name="openai/whisper-tiny",  # ask for a custom ASR model
)
audio = model.generate(
    text="Offline lazy ASR check.",
    ref_audio="ref.wav",  # no ref_text -> lazy ASR load
)
```

Running the above with `HF_HUB_OFFLINE=1` and a local cache that contains `openai/whisper-tiny` but **not** `openai/whisper-large-v3-turbo`:

**Before** (master):

```
INFO Loading ASR model openai/whisper-large-v3-turbo ...
LocalEntryNotFoundError: Cannot find an appropriate cached snapshot folder for the
specified revision on the local disk and outgoing traffic has been disabled.
```

i.e. `asr_model_name` was ignored; online this silently downloads ~1.6 GB to the default cache.

**After** (this PR):

```
INFO Loading ASR model openai/whisper-tiny ...
RESULT: SUCCESS - generated 1.98s audio
```

## Verification

- End-to-end on Apple Silicon (MPS, fp16): auto-voice generation → voice cloning with `ref_audio` and no `ref_text` → lazy load picks up the configured model → transcription and generation complete normally.
- Offline determinism check above (master fails fetching the hardcoded model, this branch succeeds fully offline).
- `pre-commit run --all-files` passes.

Fixes #175
