### PR TITLE
Add VoiceClonePrompt.save()/load() for cross-session voice reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,24 @@ audio = model.generate(
 sf.write("out.wav", audio[0], 24000)
 ```
 
+#### Reusing a cloned voice across sessions
+
+Encode the reference audio once, save the resulting prompt, and skip the
+audio loading / auto-transcription steps in later sessions:
+
+```python
+prompt = model.create_voice_clone_prompt(
+    ref_audio="ref.wav", ref_text="Transcription of the reference audio."
+)
+prompt.save("my_voice.pt")
+
+# Later, in a new session:
+from omnivoice import VoiceClonePrompt
+
+prompt = VoiceClonePrompt.load("my_voice.pt")
+audio = model.generate(text="Hello again!", voice_clone_prompt=prompt)
+```
+
 > **Tips**
 >
 > - Use a 3–10 seconds reference audio clip. Longer audio slows down inference and may degrade cloning quality.

--- a/omnivoice/__init__.py
+++ b/omnivoice/__init__.py
@@ -23,6 +23,12 @@ from omnivoice.models.omnivoice import (
     OmniVoice,
     OmniVoiceConfig,
     OmniVoiceGenerationConfig,
+    VoiceClonePrompt,
 )
 
-__all__ = ["OmniVoice", "OmniVoiceConfig", "OmniVoiceGenerationConfig"]
+__all__ = [
+    "OmniVoice",
+    "OmniVoiceConfig",
+    "OmniVoiceGenerationConfig",
+    "VoiceClonePrompt",
+]

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -113,11 +113,59 @@ def _autocast_flex_attention(module, query, key, value, *args, **kwargs):
 # ---------------------------------------------------------------------------
 
 
+_VOICE_CLONE_PROMPT_FORMAT_VERSION = 1
+
+
 @dataclass
 class VoiceClonePrompt:
     ref_audio_tokens: torch.Tensor  # (C, T)
     ref_text: str
     ref_rms: float
+
+    def save(self, path: str) -> None:
+        """Save this prompt to ``path`` for reuse in a later session.
+
+        The file stores a plain dict with the audio tokens moved to CPU, so
+        it can be loaded with ``torch.load(weights_only=True)`` (the default
+        since torch 2.6) and is portable across devices.
+
+        Args:
+            path: Destination file path (e.g. ``"my_voice.pt"``).
+        """
+        torch.save(
+            {
+                "format_version": _VOICE_CLONE_PROMPT_FORMAT_VERSION,
+                "ref_audio_tokens": self.ref_audio_tokens.detach().cpu(),
+                "ref_text": self.ref_text,
+                "ref_rms": float(self.ref_rms),
+            },
+            path,
+        )
+
+    @classmethod
+    def load(cls, path: str, map_location: str = "cpu") -> "VoiceClonePrompt":
+        """Load a prompt saved with :meth:`save`.
+
+        The returned prompt can be passed directly to
+        :meth:`OmniVoice.generate`; the audio tokens are moved to the model
+        device automatically during generation, so no manual ``.to(device)``
+        is needed.
+
+        Args:
+            path: File path previously written by :meth:`save`.
+            map_location: Device to load the audio tokens onto.
+        Returns:
+            The restored :class:`VoiceClonePrompt`.
+        """
+        data = torch.load(path, map_location=map_location, weights_only=True)
+        version = data.get("format_version")
+        if version != _VOICE_CLONE_PROMPT_FORMAT_VERSION:
+            raise ValueError(f"Unsupported VoiceClonePrompt format version: {version}")
+        return cls(
+            ref_audio_tokens=data["ref_audio_tokens"],
+            ref_text=data["ref_text"],
+            ref_rms=data["ref_rms"],
+        )
 
 
 @dataclass
@@ -555,7 +603,8 @@ class OmniVoice(PreTrainedModel):
             ref_text: Optional reference text for voice cloning mode.
             ref_audio: Optional reference audio for voice cloning mode.
                 Can be a file path or a (waveform, sample_rate) tuple.
-            voice_clone_prompt: Reusable prompt from :meth:`create_voice_clone_prompt`.
+            voice_clone_prompt: Reusable prompt from :meth:`create_voice_clone_prompt`
+                or :meth:`VoiceClonePrompt.load`.
                 If provided, it overrides ``ref_text`` and ``ref_audio``.
             instruct: Style instruction for voice design mode.
             duration: Fixed output duration in seconds. If a single float,


### PR DESCRIPTION
This adds `VoiceClonePrompt.save(path)` and `VoiceClonePrompt.load(path)` so a cloned voice can be persisted and reused across sessions, plus a short README example. Refs #54, #169, #44.

## Motivation

In #169 you pointed out that `create_voice_clone_prompt()` can be reused across `generate()` calls — that works within one session, but the prompt cannot be persisted, so every new session pays the full cost again: audio loading, silence trimming, tokenization, and (when `ref_text` is omitted) loading Whisper and running ASR. For the batch use case in #169 (1k+ files over multiple runs) this is significant, and because auto-transcription can vary slightly between runs, recomputing also means the prompt is not reproducible. #54's ask for saved voices needs an on-disk format as its first building block.

## Why an official format instead of "just `torch.save` the object"

With torch >= 2.6 (`weights_only=True` became the `torch.load` default; this repo pins torch 2.8), pickling the dataclass directly produces a file that fails to load by default:

```python
torch.save(prompt, "naive.pt")
torch.load("naive.pt")
# _pickle.UnpicklingError: Weights only load failed. ...
# Re-running `torch.load` with `weights_only` set to `False` will likely succeed,
# but it can result in arbitrary code execution. ...
```

So the DIY route pushes users toward `weights_only=False`, which is exactly the footgun the torch default is trying to prevent. This PR instead saves a version-tagged plain dict (tensor moved to CPU), which loads cleanly under `weights_only=True` and is portable across devices (CUDA/MPS/CPU).

## Design notes

- Pure addition: no existing code path changes, no new dependencies, no change to `generate()` behavior.
- Tokens are stored on CPU; on load, nothing needs to be moved manually — `_prepare_inference_inputs` already does `.to(self.device)` when the prompt is consumed.
- `format_version` field allows the format to evolve without breaking old files.
- `VoiceClonePrompt` is now exported from `omnivoice` so the README example works with a plain import.
- The voice-library manager in #166 covers a broader scope (named library, demo UI); this PR only adds the minimal serialization primitive on the existing dataclass, which such a library could build on.

## Verification (Apple Silicon, MPS, torch 2.8.0)

Session 1 — create, save, round-trip check, generate:

```python
model = OmniVoice.from_pretrained("k2-fsa/OmniVoice", device_map="mps", dtype=torch.float16)
p = model.create_voice_clone_prompt(ref_audio="ref.wav")   # 228s incl. Whisper download + ASR
p.save("my_voice.pt")
q = VoiceClonePrompt.load("my_voice.pt")
assert torch.equal(p.ref_audio_tokens.cpu(), q.ref_audio_tokens)  # bitwise identical
assert p.ref_text == q.ref_text and p.ref_rms == q.ref_rms
audio = model.generate(text="This voice was saved and loaded from disk.", voice_clone_prompt=q)  # OK
```

Session 2 — fresh process:

```python
model = OmniVoice.from_pretrained("k2-fsa/OmniVoice", device_map="mps", dtype=torch.float16)
p = VoiceClonePrompt.load("my_voice.pt")                   # 1.4 ms
audio = model.generate(text="Loaded in a completely new session.", voice_clone_prompt=p)  # OK
assert model._asr_pipe is None                              # Whisper never loaded
```

The saved prompt is byte-identical across sessions, and the second session never loads the ASR model at all.

`pre-commit run --all-files` passes.
