### PR TITLE
Fix ASR model always loading on GPU 0; add asr_device option

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ audio = model.generate(
 # If you don't want to input `ref_text` manually, you can directly omit the `ref_text`.
 # The model will use Whisper ASR to auto-transcribe it. To use a local copy (or
 # a different Whisper model), pass `asr_model_name="..."` to `from_pretrained`.
+# To control which device Whisper is loaded on (e.g. another GPU in multi-GPU
+# setups, or the CPU), pass `asr_device="cuda:1"` (or `"cpu"`).
 
 sf.write("out.wav", audio[0], 24000)
 ```

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -275,12 +275,14 @@ class OmniVoice(PreTrainedModel):
         self.sampling_rate = None
         self._asr_pipe = None
         self._asr_model_name = "openai/whisper-large-v3-turbo"
+        self._asr_device = None
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
         train_mode = kwargs.pop("train", False)
         load_asr = kwargs.pop("load_asr", False)
         asr_model_name = kwargs.pop("asr_model_name", None)
+        asr_device = kwargs.pop("asr_device", None)
 
         # Suppress noisy INFO logs from transformers/huggingface_hub during loading
         _prev_disable = logging.root.manager.disable
@@ -320,6 +322,8 @@ class OmniVoice(PreTrainedModel):
 
                 if asr_model_name is not None:
                     model._asr_model_name = asr_model_name
+                if asr_device is not None:
+                    model._asr_device = asr_device
                 if load_asr:
                     model.load_asr_model()
         finally:
@@ -331,7 +335,9 @@ class OmniVoice(PreTrainedModel):
     # ASR support (optional, for auto-transcription)
     # -------------------------------------------------------------------
 
-    def load_asr_model(self, model_name: Optional[str] = None):
+    def load_asr_model(
+        self, model_name: Optional[str] = None, device: Optional[str] = None
+    ):
         """Load a Whisper ASR model for reference audio transcription.
 
         Args:
@@ -339,28 +345,36 @@ class OmniVoice(PreTrainedModel):
                 model. Defaults to the ``asr_model_name`` passed to
                 :meth:`from_pretrained` (``openai/whisper-large-v3-turbo``
                 if unset).
+            device: Device to load the ASR model on (e.g. ``"cuda:1"`` or
+                ``"cpu"``). Defaults to the ``asr_device`` passed to
+                :meth:`from_pretrained`, falling back to the main model's
+                device (its first shard when sharded across GPUs).
         """
         from transformers import pipeline as hf_pipeline
 
         if model_name is None:
             model_name = self._asr_model_name
+        if device is None:
+            device = self._asr_device if self._asr_device is not None else self.device
 
         logger.info("Loading ASR model %s ...", model_name)
         asr_dtype = (
-            torch.float16
-            if str(self.device).startswith(("cuda", "xpu"))
-            else torch.float32
+            torch.float16 if str(device).startswith(("cuda", "xpu")) else torch.float32
         )
 
         model_name = _resolve_model_path(model_name)
 
+        # Use `device=` (single-device placement) rather than `device_map=`:
+        # pipeline() ignores a plain device string in `device_map` and
+        # auto-selects an accelerator, which is why the ASR model could not
+        # be moved off the default GPU (#180).
         self._asr_pipe = hf_pipeline(
             "automatic-speech-recognition",
             model=model_name,
             dtype=asr_dtype,
-            device_map=self.device,
+            device=device,
         )
-        logger.info("ASR model loaded on %s.", self.device)
+        logger.info("ASR model loaded on %s.", device)
 
     @torch.inference_mode()
     def transcribe(


### PR DESCRIPTION
Fixes #180.

## Root cause

`load_asr_model()` passes the target device to `transformers.pipeline()` via `device_map=`. A plain device (e.g. `torch.device("cuda:1")`, `"cpu"`) passed as `device_map` is not honored for single-device placement — the pipeline auto-selects an accelerator, which in practice is always GPU 0. So the Whisper model lands on `cuda:0` no matter where the main model lives, and there is no way to redirect it — which matches the screenshots in #180 ("绑不上去").

The current log line even reports the wrong thing. On master, with the main model pinned to `cuda:1` (2x H100 NVL):

```python
m = OmniVoice.from_pretrained("k2-fsa/OmniVoice", device_map="cuda:1", dtype=torch.float16)
m.load_asr_model()          # logs "ASR model loaded on cuda:1."
m._asr_pipe.model.device    # -> device(type='cuda', index=0)   (actually on GPU 0)
```

## Fix

- Use `device=` (single-device placement, honored by the pipeline) instead of `device_map=`. The default behavior now does what the log line always claimed: the ASR model follows the main model's device.
- Add an `asr_device` kwarg to `from_pretrained` and a `device` parameter to `load_asr_model()` (same plumbing as `asr_model_name`, #221), so multi-GPU deployments can place Whisper explicitly — e.g. on a second GPU (the #180 use case) or on the CPU:

```python
# spread across GPUs
model = OmniVoice.from_pretrained("k2-fsa/OmniVoice", device_map="cuda:0",
                                  dtype=torch.float16, asr_device="cuda:1")
# or keep Whisper off the GPUs entirely
model.load_asr_model(device="cpu")
```

The ASR dtype selection (fp16 on cuda/xpu, fp32 otherwise) now keys off the ASR device instead of the main model device, so `asr_device="cpu"` correctly gets fp32.

## Verification (2x NVIDIA H100 NVL, torch 2.8.0 + Apple Silicon MPS)

Before (master `1574e06`):

| setup | main model | ASR lands on |
|---|---|---|
| `device_map="cuda:1"` | cuda:1 | **cuda:0** (wrong GPU) |
| `device_map="auto"` (sharded 2 GPUs) | shards on 0+1 | **cuda:0** (no way to move) |
| `asr_device=...` | — | `TypeError` (no such option) |

After (this branch):

| setup | ASR lands on |
|---|---|
| `device_map="cuda:1"`, default ASR | cuda:1 (follows main model) |
| `device_map="auto"` + `asr_device="cuda:1"` | cuda:1, fp16 |
| `load_asr_model(device="cpu")` per-call | cpu, fp32 |
| MPS Mac + `asr_device="cpu"` | cpu; auto-transcription output unchanged |

End-to-end on `cuda:1` after the fix: `generate(text=..., instruct="male, low pitch")` produces normal audio (2.44 s), and auto-transcription of a reference clip returns the same text as before the change.

Single-GPU and Mac setups are unaffected: there the auto-selected device and the main model device coincide, so placement is identical to before.

`pre-commit run --all-files` passes.
