### PR TITLE
Add experimental native narration controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 /exp*/
 /.tmp/
 /results/
+/outputs/
 /data/
 /download
 /local/

--- a/README.md
+++ b/README.md
@@ -218,6 +218,57 @@ audio = model.generate(
 ```
 See more detailed control in [docs/generation-parameters.md](docs/generation-parameters.md).
 
+### Native Pause Control Experiment
+
+This branch adds fixed codec-token pauses without inserting silence into the
+decoded waveform. Inline markers are removed before text tokenization:
+
+```python
+audio = model.generate(
+    text="The first result passed.<pause:0.80> The second exposed the bug.",
+    ref_audio="ref.wav",
+    ref_text="Reference transcript.",
+)
+```
+
+Structured controls use character offsets in cleaned text:
+
+```python
+from omnivoice import PausePlan, PauseSpec
+
+text = "The first result passed. The second exposed the bug."
+audio = model.generate(
+    text=text,
+    pause_plan=PausePlan((PauseSpec(after_char=24, seconds=0.8),)),
+)
+```
+
+- Batch text requires a same-length `pause_plan` list; use `None` for
+  uncontrolled items.
+- Inline markers and a structured plan cannot control the same item.
+- `duration` keeps its existing final-total meaning. Fixed pause frames consume
+  part of that total, while `speed` changes speech frames only.
+- `pause_audio=None` encodes digital silence. A mono/stereo path or
+  `(waveform, sample_rate)` tuple supplies shared room tone, which must be long
+  enough for the longest requested pause.
+- Controlled items are short-form only and raise if they cross
+  `audio_chunk_threshold`. Uncontrolled long-form items can remain in a mixed
+  batch.
+- Controlled postprocessing keeps internal silence while retaining edge trim,
+  normalization, fade, and padding. `postprocess_output=False` keeps upstream
+  behavior.
+
+Validation commands:
+
+```bash
+.venv/bin/python scripts/pause_smoke.py --preset quick --num-step 32
+.venv/bin/python scripts/pause_smoke.py --preset acceptance --num-step 128 \
+  --report reports/pause_smoke_results.json
+```
+
+Generated WAVs and token tensors live under ignored `outputs/pause_smoke/`.
+See `findings.md` and `reports/pause_smoke_results.json` for measured results.
+
 ### Non-Verbal & Pronunciation Control
 
 OmniVoice supports inline **non-verbal symbols** and **pronunciation correction** within the input text.

--- a/README.md
+++ b/README.md
@@ -263,11 +263,18 @@ Validation commands:
 ```bash
 .venv/bin/python scripts/pause_smoke.py --preset quick --num-step 32
 .venv/bin/python scripts/pause_smoke.py --preset acceptance --num-step 128 \
+  --two-pass-fallback \
   --report reports/pause_smoke_results.json
 ```
 
 Generated WAVs and token tensors live under ignored `outputs/pause_smoke/`.
 See `findings.md` and `reports/pause_smoke_results.json` for measured results.
+
+`--two-pass-fallback` runs only for failed one-pass cases. It retains the
+marker-free baseline tokens, inserts fixed pause tokens at the ASR-aligned
+boundary midpoint, remasks five codec frames on each side, and regenerates only
+those transition windows. Alignment stays in the validation script;
+`OmniVoice.generate()` never invokes ASR or the fallback automatically.
 
 ### Non-Verbal & Pronunciation Control
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,28 @@ result = controller.generate(
   generation and acoustic ranking, so strength can be subtle and must be
   approved by listening.
 
+CMU conditioning can guide pronunciation during legacy full-codebook
+regeneration without changing alignment text:
+
+```python
+result = controller.generate(
+    'This was <emphasis strength="strong">unexpected</emphasis>.',
+    voice_clone_prompt=prompt,
+    pronunciations={
+        "unexpected": "AH2 N IH0 K S P EH1 K T IH0 D",
+    },
+    num_step=128,
+    candidates=3,
+)
+```
+
+Pronunciation keys must exactly match controlled text spans. Values accept CMU
+ARPABET with or without surrounding brackets. The controller keeps normal text
+for offsets and ASR, but internally conditions generation with the bracketed
+phonemes. Phones are validated before model generation. Use verified CMUdict
+entries; this option cannot fix a word already mispronounced in the marker-free
+baseline.
+
 Generate local A/B audio examples:
 
 ```bash
@@ -371,6 +393,17 @@ WAVs are written under ignored `outputs/narration_controls/`. Compare
 `acceptance/baseline.wav` with `rate_slow.wav`, `rate_fast.wav`,
 `emphasis_moderate.wav`, `emphasis_strong.wav`, `intonation_rising.wav`,
 `intonation_falling.wav`, and `aside.wav`.
+
+Generate the CMU pronunciation comparison matrix:
+
+```bash
+.venv/bin/python scripts/cmu_pronunciation_smoke.py \
+  --num-step 128 --candidates 3
+```
+
+WAVs are written under ignored
+`outputs/narration_controls/cmu_pronunciation/`. Automated measurements are
+tracked in `reports/cmu_pronunciation_results.json`.
 
 ### Non-Verbal & Pronunciation Control
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,102 @@ boundary midpoint, remasks five codec frames on each side, and regenerates only
 those transition windows. Alignment stays in the validation script;
 `OmniVoice.generate()` never invokes ASR or the fallback automatically.
 
+### Single-Reference Narration Controls Experiment
+
+This branch can change local delivery while reusing one permanent clone prompt.
+It does not switch reference recordings. Baseline codec tokens outside the
+selected control and five-frame transition windows remain fixed.
+
+Install the optional local aligner dependency:
+
+```bash
+pip install -e ".[narration]"
+```
+
+Create the clone prompt once, then reuse it for every controlled line:
+
+```python
+import soundfile as sf
+import torch
+
+from omnivoice import NarrationController, OmniVoice
+
+model = OmniVoice.from_pretrained(
+    "k2-fsa/OmniVoice",
+    device_map="cuda:0",
+    dtype=torch.float16,
+)
+prompt = model.create_voice_clone_prompt(
+    "ref.wav",
+    "Exact transcript of the one permanent reference recording.",
+)
+controller = NarrationController(model)
+
+result = controller.generate(
+    'The result looked ordinary, but it was '
+    '<emphasis strength="strong">not</emphasis> ordinary.',
+    voice_clone_prompt=prompt,
+    num_step=128,
+    candidates=3,
+)
+sf.write("controlled.wav", result.audio, result.sample_rate)
+```
+
+Supported explicit controls:
+
+```text
+<rate value="0.85">slower phrase</rate>
+<rate value="1.20">faster phrase</rate>
+<emphasis strength="reduced">de-emphasized words</emphasis>
+<emphasis strength="moderate">important words</emphasis>
+<emphasis strength="strong">critical words</emphasis>
+<intonation type="rising">A rising ending</intonation>
+<intonation type="falling">A final ending</intonation>
+<aside>parenthetical delivery</aside>
+<pause:0.80>
+```
+
+Optional shorthand is parsed only with `shorthand=True`:
+
+```python
+result = controller.generate(
+    "This is **important**. This is ***critical***. "
+    "(Keep this as an aside.) The answer — absolutely — changed.",
+    voice_clone_prompt=prompt,
+    shorthand=True,
+)
+```
+
+- `**text**` means moderate emphasis; `***text***` means strong emphasis.
+- `(text)` means aside delivery; `— text —` means isolated strong emphasis.
+- Explicit markup is safer when literal parentheses or em dashes should remain.
+- Rate values range from `0.7` to `1.4`; values above `1.0` are faster.
+- Controls cannot nest or overlap. Pause markers cannot sit inside another
+  control. Malformed controls raise before tokenization.
+- Current implementation supports one English short-form item per call because
+  it uses local faster-whisper word alignment. It never runs ASR through
+  `OmniVoice.generate()` itself.
+- All final speech remains codec-generated. No waveform concatenation or
+  reference switching is used.
+- Rate is most deterministic. Emphasis, aside, and intonation use candidate
+  generation and acoustic ranking, so strength can be subtle and must be
+  approved by listening.
+
+Generate local A/B audio examples:
+
+```bash
+.venv/bin/python scripts/narration_control_smoke.py \
+  --preset quick --num-step 32 --candidates 1
+.venv/bin/python scripts/narration_control_smoke.py \
+  --preset acceptance --num-step 128 --candidates 3 \
+  --report reports/narration_control_results.json
+```
+
+WAVs are written under ignored `outputs/narration_controls/`. Compare
+`acceptance/baseline.wav` with `rate_slow.wav`, `rate_fast.wav`,
+`emphasis_moderate.wav`, `emphasis_strong.wav`, `intonation_rising.wav`,
+`intonation_falling.wav`, and `aside.wav`.
+
 ### Non-Verbal & Pronunciation Control
 
 OmniVoice supports inline **non-verbal symbols** and **pronunciation correction** within the input text.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ See more detailed control in [docs/generation-parameters.md](docs/generation-par
 
 ### Native Pause Control Experiment
 
+Full implementation notes, experiment history, validation, and limitations are
+documented in
+[`docs/narration-control-experiments.md`](docs/narration-control-experiments.md).
+
 This branch adds fixed codec-token pauses without inserting silence into the
 decoded waveform. Inline markers are removed before text tokenization:
 

--- a/docs/narration-control-experiments.md
+++ b/docs/narration-control-experiments.md
@@ -1,0 +1,387 @@
+# Native Pause and Single-Reference Narration Controls
+
+## Purpose
+
+This document records the OmniVoice experiments implemented on top of version
+`0.2.0`. The work stays inside the OmniVoice package. It does not depend on the
+GenTest viewer or any website UI.
+
+The main goal was to control pauses and local delivery while keeping one voice
+clone reference. Changing reference audio was explicitly avoided because even
+references made from the same identity produced small identity and style shifts.
+
+The branch contains three related systems:
+
+1. Native fixed-token pauses in `OmniVoice.generate()`.
+2. Single-reference narration controls through `NarrationController`.
+3. Generation traces and a standalone native diagnostic capture script.
+
+Pronunciation-safe protected-codebook inpainting was also tested on a separate
+branch. It is documented here as a rejected experiment and is not included in
+the current implementation.
+
+## Revisions and Runtime
+
+- Upstream source: `3d2bd9d07bbe8d16c2439745b0ded450dc41e215`
+  (`0.2.0`).
+- Model snapshot: `c5fdb5ccb189668d56333f77ba2629f4cd7535f4`.
+- Alignment snapshot: `d1d751a5f8271d482d14ca55d9e2deeebbae577f`.
+- Main experiment revisions:
+  - `dc21d79`: native pause token controls.
+  - `7ed42cb`: conditional boundary-inpainting fallback.
+  - `2aa3993`: single-reference narration controls.
+  - `7561686`: CMU-conditioned narration controls.
+  - `8e6dcb9`: generation traces.
+  - `7a55ebd`: native generation diagnostic capture.
+- Acceptance runtime: Python 3.11.14, Torch 2.8.0+cu128, CUDA 12.8,
+  RTX 4070 SUPER.
+
+## Native Pause Controls
+
+### Public API
+
+Inline pause markers are removed before tokenization:
+
+```python
+audio = model.generate(
+    text="The first result passed.<pause:0.80> The second exposed the bug.",
+    ref_audio="ref.wav",
+    ref_text="Exact reference transcript.",
+)
+```
+
+Structured plans use offsets in cleaned text:
+
+```python
+from omnivoice import PausePlan, PauseSpec
+
+text = "The first result passed. The second exposed the bug."
+audio = model.generate(
+    text=text,
+    pause_plan=PausePlan((PauseSpec(after_char=24, seconds=0.8),)),
+    ref_audio="ref.wav",
+    ref_text="Exact reference transcript.",
+)
+```
+
+`pause_audio` accepts either a path or `(waveform, sample_rate)`. When omitted,
+the audio tokenizer encodes exact digital silence. When supplied, the source is
+converted to mono 24 kHz and center-cropped for every requested pause.
+
+### Parsing and Validation
+
+- Marker parsing happens before every tokenizer call.
+- Malformed `<pause...>` fragments raise instead of reaching the tokenizer.
+- Leading, trailing, zero, negative, and nonfinite pauses are rejected.
+- Adjacent pauses at the same character boundary are merged.
+- Explicit and inline plans cannot control the same batch item.
+- Batch plans must match batch size; `None` leaves an item uncontrolled.
+- Pause duration converts to 25 Hz codec frames with round-half-up semantics.
+
+### Frame Planning
+
+- Speech duration is estimated once from full cleaned text.
+- `speed` changes speech frames only.
+- Without `duration`, final frames equal speech frames plus pause frames.
+- With `duration`, pauses consume part of the requested final total.
+- Phrase boundaries follow cumulative duration-estimator weights.
+- Allocation reserves at least one speech frame for every nonempty phrase.
+- Controlled long-form items are rejected; uncontrolled long-form items remain
+  valid in a mixed batch.
+
+### Diffusion and Fixed Tokens
+
+The pause layout becomes a target token template. Pause codec tokens are fixed;
+speech positions remain masked. Conditional and unconditional classifier-free
+guidance branches receive the same template.
+
+The iterative sampler was changed to:
+
+- derive schedules from each item's real mask count;
+- skip items with no remaining masks;
+- clamp `topk` to remaining masks;
+- exclude fixed positions from sampling;
+- update conditional and unconditional target slices together;
+- check fixed tokens after every diffusion step;
+- preserve the original all-mask schedule, sampling order, and random-number
+  behavior for uncontrolled items.
+
+This last property was verified against pristine `0.2.0`: seeded uncontrolled
+output remained exactly equal at the codec-token level (`8 x 129`, zero token
+differences).
+
+### Postprocessing
+
+Uncontrolled output follows the original postprocessing path. Controlled output
+keeps internal silence instead of collapsing it, while retaining edge trimming,
+normalization, fades, and edge padding. No waveform silence is inserted after
+generation.
+
+## Single-Reference Narration Controls
+
+### Public API
+
+Install the optional local aligner:
+
+```bash
+pip install -e ".[narration]"
+```
+
+Create one prompt and reuse it:
+
+```python
+import soundfile as sf
+import torch
+
+from omnivoice import NarrationController, OmniVoice
+
+model = OmniVoice.from_pretrained(
+    "k2-fsa/OmniVoice",
+    device_map="cuda:0",
+    dtype=torch.float16,
+)
+prompt = model.create_voice_clone_prompt(
+    "ref.wav",
+    "Exact transcript of the permanent reference recording.",
+)
+controller = NarrationController(model)
+
+result = controller.generate(
+    'The result looked ordinary, but it was '
+    '<emphasis strength="strong">not</emphasis> ordinary.',
+    voice_clone_prompt=prompt,
+    num_step=128,
+    candidates=3,
+)
+sf.write("controlled.wav", result.audio, result.sample_rate)
+```
+
+Supported controls:
+
+```text
+<rate value="0.85">slower phrase</rate>
+<rate value="1.20">faster phrase</rate>
+<emphasis strength="reduced">de-emphasized words</emphasis>
+<emphasis strength="moderate">important words</emphasis>
+<emphasis strength="strong">critical words</emphasis>
+<intonation type="rising">rising ending</intonation>
+<intonation type="falling">falling ending</intonation>
+<aside>parenthetical delivery</aside>
+<pause:0.80>
+```
+
+Optional shorthand is enabled only with `shorthand=True`:
+
+- `**text**`: moderate emphasis.
+- `***text***`: strong emphasis.
+- `(text)`: aside delivery.
+- `-- text --` written with em dashes in input: isolated strong emphasis.
+
+Explicit markup is safer when parentheses or dashes are literal prose.
+
+### How Local Control Works
+
+`NarrationController` generates a marker-free baseline, aligns expected words,
+and maps each character span to codec frames. It then rebuilds only the selected
+span plus five transition frames on each side.
+
+Every codec token outside the local inpaint window stays fixed. The controller
+generates multiple candidates and ranks them using:
+
+- word-sequence preservation;
+- requested duration for rate controls;
+- prominence and duration proxies for emphasis and aside;
+- pitch direction for intonation;
+- fixed-token integrity.
+
+Final audio is decoded from the final codec tensor. The system does not splice
+waveforms and does not switch voice references.
+
+### Parser Rules
+
+- Controls cannot nest or overlap.
+- Empty controls are rejected.
+- Rate values must remain between `0.7` and `1.4`.
+- Pause markers cannot sit inside a regional control.
+- Malformed tags and unsupported attributes raise before model generation.
+- The current controller supports one English short-form item per call.
+
+Rate is the most deterministic control. Emphasis, aside, and intonation depend
+on candidate generation and acoustic ranking. The requested effect can remain
+subtle even when automated checks pass.
+
+## CMU Pronunciation Conditioning
+
+Legacy full-codebook regeneration sometimes changed pronunciation while giving
+the strongest emphasis. CMU ARPABET conditioning was added to retain that
+freedom while guiding the controlled word's phonemes.
+
+```python
+result = controller.generate(
+    'This was <emphasis strength="strong">unexpected</emphasis>.',
+    voice_clone_prompt=prompt,
+    pronunciations={
+        "unexpected": "AH2 N IH0 K S P EH1 K T IH0 D",
+    },
+    num_step=128,
+    candidates=3,
+)
+```
+
+Behavior:
+
+- Values accept ARPABET with or without brackets.
+- Vowels require stress `0`, `1`, or `2`; consonants reject stress.
+- Normal text remains the source of offsets, alignment, and expected ASR words.
+- Bracketed phonemes are used only for internal generation conditioning.
+- Pronunciations apply both inside and outside regional controls.
+- Pause offsets are remapped after phoneme substitution.
+- A pause cannot split a pronunciation-controlled word.
+
+Informal listening during development found CMU conditioning fixed the cited
+`unexpected`, `genuine`, and `nobody` failures while preserving useful emphasis.
+The tracked automated reports still label perceptual pronunciation and identity
+approval as manual because ASR and waveform metrics cannot prove them.
+
+## Rejected Protected-Codebook Experiment
+
+A separate `experiment/pronunciation-safe-controls` branch tested preserving one
+to four early codec codebooks inside the controlled window. It kept original
+word duration and reduced phonetic rewriting, but it also removed most useful
+emphasis. Listening found the new outputs very close to baseline.
+
+Decision: do not include protected-codebook safe mode. Keep legacy full-codebook
+regeneration and use explicit CMU conditioning when pronunciation needs help.
+
+## Generation Traces and Native Diagnostics
+
+Trace mode records per codebook and codec frame:
+
+- unmask step;
+- selected token log probability;
+- entropy;
+- classifier-free-guidance delta;
+- fixed-token mask;
+- pause-token mask;
+- final tokens.
+
+These traces support debugging and future editors without changing generated
+audio. `narration_capabilities()` exposes a stable, model-free schema for the
+available controls and trace fields.
+
+`scripts/native_generation_capture.py` captures a standalone diagnostic bundle
+without Whisper or external alignment. It records:
+
+- duration-estimator word locations;
+- punctuation boundaries;
+- decoded RMS and pitch per 40 ms codec frame;
+- token uncertainty and decode order;
+- codec similarity to tokenizer-encoded digital silence;
+- inferred pause candidates;
+- raw and postprocessed audio plus hashes and runtime metadata.
+
+These values describe model generation evidence, not semantic intent. Native
+tokens cannot reliably say that a phrase was an aside or that a word was
+emphasized. Natural pause candidates are inferred from energy and silence-token
+similarity; they are not exact model annotations.
+
+## Validation
+
+### Automated tests
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+Coverage includes parsing, frame math, batch behavior, fixed-token templates,
+diffusion schedules, postprocessing, uncontrolled compatibility, narration
+candidate selection, CMU validation, pause remapping, and trace integrity.
+
+### Pause smoke tests
+
+```bash
+.venv/bin/python scripts/pause_smoke.py --preset quick --num-step 32
+.venv/bin/python scripts/pause_smoke.py \
+  --preset acceptance --num-step 128 --two-pass-fallback \
+  --report reports/pause_smoke_results.json
+```
+
+### Narration smoke tests
+
+```bash
+.venv/bin/python scripts/narration_control_smoke.py \
+  --preset quick --num-step 32 --candidates 1
+.venv/bin/python scripts/narration_control_smoke.py \
+  --preset acceptance --num-step 128 --candidates 3 \
+  --report reports/narration_control_results.json
+```
+
+### CMU matrix
+
+```bash
+.venv/bin/python scripts/cmu_pronunciation_smoke.py \
+  --num-step 128 --candidates 3
+```
+
+Generated WAVs remain ignored under `outputs/`. Tracked JSON reports contain
+settings, revisions, hashes, transcripts, timing, memory, and acoustic metrics.
+
+## Results and Decisions
+
+### Native pause control
+
+One-pass full acceptance passed only the primary 0.80-second case. The 0.40,
+1.20, and secondary-reference 0.80 cases missed the strict 120 ms incremental
+pause tolerance after postprocessing. Two-pass boundary inpainting repaired two
+of three failures; the primary 1.20 case still missed by 160 ms.
+
+Decision: fixed-token pauses are technically real, but the complete strict
+acceptance matrix failed. Keep pause control experimental. Do not claim exact
+perceptual duration from codec-frame count alone.
+
+### Narration controls
+
+The 128-step, three-candidate matrix preserved normalized word sequence and
+fixed codec tokens in all cases. Slow and fast rate hit duration targets. Aside,
+moderate emphasis, strong emphasis, rising intonation, and falling intonation
+all produced measurable local changes.
+
+Decision: single-reference narration control is technically viable. Rate and
+aside are strongest objectively. Emphasis and intonation remain listening-gated.
+
+### CMU conditioning
+
+Automated cases preserved expected words for `unexpected`, `nobody`, and native
+bracket variants of `genuine`. CMU changed the balance among duration, pitch,
+and loudness instead of guaranteeing louder emphasis.
+
+Decision: CMU conditioning is the preferred pronunciation guard for legacy
+full-codebook emphasis. Use verified CMUdict entries and keep human review.
+
+## Known Limits
+
+- Short-form English only for `NarrationController`.
+- Local faster-whisper alignment is required for narration controls.
+- No automatic ASR or fallback inside `OmniVoice.generate()`.
+- No automatic semantic detection of emphasis or aside.
+- No waveform concatenation.
+- No reference switching.
+- Exact pause frame count does not guarantee exact perceived pause duration.
+- ASR word preservation does not prove correct pronunciation, identity, clicks,
+  transition naturalness, or intended emotional delivery.
+- Human listening remains the final acceptance gate.
+
+## File Map
+
+- `omnivoice/controls.py`: pause parsing, validation, and frame layout.
+- `omnivoice/models/omnivoice.py`: public pause API, templates, diffusion, trace
+  capture, and controlled postprocessing.
+- `omnivoice/narration.py`: markup, shorthand, local inpainting, candidate
+  ranking, CMU conditioning, reports, and capability schema.
+- `scripts/pause_smoke.py`: pause acceptance and two-pass fallback.
+- `scripts/narration_control_smoke.py`: narration-control A/B matrix.
+- `scripts/cmu_pronunciation_smoke.py`: pronunciation comparison matrix.
+- `scripts/native_generation_capture.py`: native trace and pause evidence bundle.
+- `reports/*.json`: tracked reproducibility and acceptance data.
+- `findings.md`: concise experiment decisions.
+

--- a/findings.md
+++ b/findings.md
@@ -51,9 +51,25 @@ strict gate, despite exact fixed-frame counts and intact text.
 
 ## Decision
 
-One-pass latent pause control is not sufficient for integration. Decision:
-`two-pass required` for failing cases. Boundary inpainting remains conditional
-and must preserve all baseline tokens outside five-frame transition windows.
+One-pass latent pause control is not sufficient for integration. Conditional
+two-pass boundary inpainting was attempted only for the three failed cases. It
+inserted fixed pause tokens at the baseline ASR boundary midpoint, remasked five
+frames on each side, and preserved every other baseline token.
+
+| Fallback case | Requested | Raw incremental | Final incremental | Result |
+|---|---:|---:|---:|---|
+| Primary 0.40 | 0.40s | 0.39s | 0.36s | Pass |
+| Primary 1.20 | 1.20s | 1.09s | 1.04s | Final exceeds tolerance |
+| Secondary 0.80 | 0.80s | 0.78s | 0.84s | Pass |
+
+All fallback cases retain WER `0.0`, exact pause-frame counts, unchanged fixed
+tokens, and unchanged baseline tokens outside transition windows. Primary 1.20
+still misses the final-output gate by 160 ms. Per experiment rules, no further
+tuning or waveform concatenation was attempted.
+
+Final decision: `latent-pause approach failed`. Do not integrate this branch as
+production pause control. Keep it as evidence that native fixed-token pauses
+work for some durations but do not meet the complete acceptance matrix.
 
 Perceptual click, codec-artifact, and transition-naturalness status:
 `manual review pending`. Waveform and ASR metrics cannot approve this gate.

--- a/findings.md
+++ b/findings.md
@@ -128,3 +128,46 @@ subtle. Keep all controls experimental until audio review confirms identity,
 naturalness, word stress, transitions, and intended pitch movement.
 
 Listening status: `manual review pending`.
+
+# CMU-Conditioned Narration Findings
+
+## Scope
+
+- Stable legacy commit: `e248cd42dba132849d2f23bb9f29e8fbe86a2ec9`
+- CMU implementation: `7561686e3405ff504778d293bdf42d47c925111b`
+- Experiment branch: `experiment/cmu-conditioned-controls`
+- Dictionary entries verified against CMUdict master and `cmudict.0.7a`.
+- Legacy full-codebook inpainting, duration expansion, candidate generation, and
+  acoustic ranking remain unchanged.
+
+The controller keeps normal words in cleaned/alignment text and substitutes
+validated bracketed ARPABET only in internal generation conditioning. This
+avoids treating individual phonemes as expected ASR words.
+
+## Automated Matrix
+
+The 128-step, three-candidate matrix used the original short clone reference.
+All controlled and native-bracket cases retained expected ASR words.
+
+| Word | Variant | Frames | Prominence change | Pitch-slope change |
+|---|---|---:|---:|---:|
+| `unexpected` | Legacy | 13 to 18 | -2.93dB | +1.44 semitones |
+| `unexpected` | CMU | 13 to 18 | -5.40dB | +5.76 semitones |
+| `nobody` | Legacy | 7 to 9 | -0.25dB | -0.48 semitones |
+| `nobody` | CMU primary | 7 to 9 | -1.23dB | -0.65 semitones |
+| `nobody` | CMU reduced vowel | 7 to 9 | -0.73dB | +0.24 semitones |
+
+Native bracket generation for plain `genuine` and both official CMU variants
+was transcribed as `genuine`. Full reports are tracked in
+`reports/cmu_pronunciation_results.json`; local WAVs are under ignored
+`outputs/narration_controls/cmu_pronunciation/`.
+
+## Decision
+
+CMU conditioning preserves legacy emphasis freedom and gives explicit phoneme
+guidance. Automated metrics cannot determine whether it fixed the audible
+mispronunciations, and the CMU variants shifted emphasis away from loudness
+toward pitch or duration. Human A/B listening is required before enabling CMU
+conditioning by default or combining it with candidate filtering.
+
+Pronunciation, emphasis, and identity status: `manual review pending`.

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,59 @@
+# Native Pause Experiment Findings
+
+## Reproducibility
+
+- Source revision: `3d2bd9d07bbe8d16c2439745b0ded450dc41e215`
+- Experiment branch: `experiment/latent-pause-control`
+- Model revision: `c5fdb5ccb189668d56333f77ba2629f4cd7535f4`
+- Aligner revision: `d1d751a5f8271d482d14ca55d9e2deeebbae577f`
+- Runtime: Python 3.11.14, Torch 2.8.0+cu128, CUDA 12.8,
+  Transformers 5.12.1, tokenizers 0.22.2, RTX 4070 SUPER
+- Primary reference: `explaining_sub_11s_24k.wav`, SHA256
+  `26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0`
+- Secondary reference: `explaining_24k.wav`, SHA256
+  `6409ff2b4dd0f0a72249e1754c42df47ecd98c64f9a34cb71df2f52f17a25fad`
+
+The system-site-packages virtual environment reports pre-existing dependency
+conflicts from the host installation. Editable OmniVoice itself imports from
+this fork and reports version `0.2.0`.
+
+## Verified Behavior
+
+- Inline and structured pause parsing, batch validation, duration/speed frame
+  planning, room-tone contracts, template placement, CFG template equality,
+  diffusion fixed-token checks, mixed mask counts, postprocessing, and API
+  compatibility pass automated tests.
+- Patched uncontrolled generation exactly matches the pristine seeded 0.2.0
+  baseline: shape `8 x 129`, zero differing codec tokens.
+- Digital silence encodes to exactly eight codebooks and the requested number
+  of 25 Hz frames. Fixed positions remain unchanged through every diffusion
+  step.
+- Quick 32-step smoke passes for the 0.80-second primary case: raw incremental
+  low-energy pause `0.78s`, final incremental pause `0.74s`, WER `0.0`.
+- Full 128-step one-pass generation preserves word order and produces WER
+  `0.0` for every controlled case. No transient metric flags an abnormal spike.
+
+## One-Pass Acceptance
+
+Full results are tracked in `reports/pause_smoke_results.json`; WAVs and token
+tensors are under ignored `outputs/pause_smoke/acceptance/`.
+
+| Case | Requested | Raw incremental | Final incremental | Result |
+|---|---:|---:|---:|---|
+| Primary 0.40 | 0.40s | 0.50s | 0.53s | Final exceeds tolerance |
+| Primary 0.80 | 0.80s | 0.79s | 0.90s | Pass |
+| Primary 1.20 | 1.20s | 1.29s | 1.33s | Final exceeds tolerance |
+| Secondary 0.80 | 0.80s | 0.67s | 0.63s | Raw and final exceed tolerance |
+
+Tolerance is absolute error at most 120 ms after subtracting the matching
+baseline low-energy span. Three of four controlled acceptance cases fail this
+strict gate, despite exact fixed-frame counts and intact text.
+
+## Decision
+
+One-pass latent pause control is not sufficient for integration. Decision:
+`two-pass required` for failing cases. Boundary inpainting remains conditional
+and must preserve all baseline tokens outside five-frame transition windows.
+
+Perceptual click, codec-artifact, and transition-naturalness status:
+`manual review pending`. Waveform and ASR metrics cannot approve this gate.

--- a/findings.md
+++ b/findings.md
@@ -73,3 +73,58 @@ work for some durations but do not meet the complete acceptance matrix.
 
 Perceptual click, codec-artifact, and transition-naturalness status:
 `manual review pending`. Waveform and ASR metrics cannot approve this gate.
+
+# Single-Reference Narration Control Findings
+
+## Scope
+
+- Experiment revision: `2aa39933b4002d2951df115c9363781d1a9f58d0`
+- Branch: `experiment/clone-narration-controls`
+- Same model, aligner, reference basename, and reference SHA256 as the pause
+  experiment above.
+- One `VoiceClonePrompt` was created once and reused for baseline, phrase rate,
+  emphasis, intonation, and aside cases. Reference switching was disabled.
+- Pronunciation and alias behavior was intentionally excluded.
+
+## Implementation
+
+`NarrationController` first generates a marker-free baseline, aligns requested
+words, retains baseline codec tokens outside the selected local window, and
+regenerates only the controlled window plus five transition frames. It ranks
+multiple candidates using transcript, duration, prominence, or pitch direction.
+Output is decoded from model codec tokens; no waveform stitching is used.
+
+Explicit controls support phrase rate, reduced/moderate/strong emphasis,
+rising/falling endings, aside delivery, and existing pauses. Optional Markdown-
+like shorthand is disabled unless `shorthand=True`.
+
+## Automated Acceptance
+
+The 128-step, three-candidate matrix used one permanent reference. Runtime was
+`141.25s` on an RTX 4070 SUPER, with about `2.20 GB` peak allocated GPU memory.
+All controlled cases preserved normalized word sequence and fixed codec tokens.
+
+| Control | Baseline | Controlled | Automated result |
+|---|---:|---:|---|
+| Slow rate `0.85` | 1.64s | 1.92s; 1.92s target | Pass |
+| Fast rate `1.20` | 1.64s | 1.38s; 1.36s target | Pass |
+| Moderate emphasis | 19 frames | 22 frames; +0.61dB prominence | Pass |
+| Strong emphasis | 19 frames, 0.74s | 26 frames, 0.90s | Pass |
+| Rising ending | -0.86 semitone slope | 0.00 semitone slope | Pass, subtle |
+| Falling ending | -0.86 semitone slope | -2.74 semitone slope | Pass |
+| Aside | 1.64s | 1.50s; -1.36dB prominence | Pass |
+
+Full candidate reports, hashes, transcripts, settings, runtime, and GPU memory
+are tracked in `reports/narration_control_results.json`. Local A/B WAVs are in
+ignored `outputs/narration_controls/acceptance/`.
+
+## Decision
+
+Single-reference local narration control is technically viable. Rate and aside
+show strongest objective behavior. Moderate/strong emphasis produce distinct
+codec-span and acoustic changes, but emphasis does not always mean louder.
+Rising intonation can neutralize a falling baseline yet remain perceptually
+subtle. Keep all controls experimental until audio review confirms identity,
+naturalness, word stress, transitions, and intended pitch movement.
+
+Listening status: `manual review pending`.

--- a/omnivoice/__init__.py
+++ b/omnivoice/__init__.py
@@ -25,6 +25,13 @@ from omnivoice.models.omnivoice import (
     OmniVoiceGenerationConfig,
 )
 from omnivoice.controls import PausePlan, PauseSpec
+from omnivoice.narration import (
+    NarrationControl,
+    NarrationController,
+    NarrationPlan,
+    NarrationResult,
+    parse_narration_controls,
+)
 
 __all__ = [
     "OmniVoice",
@@ -32,4 +39,9 @@ __all__ = [
     "OmniVoiceGenerationConfig",
     "PausePlan",
     "PauseSpec",
+    "NarrationControl",
+    "NarrationController",
+    "NarrationPlan",
+    "NarrationResult",
+    "parse_narration_controls",
 ]

--- a/omnivoice/__init__.py
+++ b/omnivoice/__init__.py
@@ -24,5 +24,12 @@ from omnivoice.models.omnivoice import (
     OmniVoiceConfig,
     OmniVoiceGenerationConfig,
 )
+from omnivoice.controls import PausePlan, PauseSpec
 
-__all__ = ["OmniVoice", "OmniVoiceConfig", "OmniVoiceGenerationConfig"]
+__all__ = [
+    "OmniVoice",
+    "OmniVoiceConfig",
+    "OmniVoiceGenerationConfig",
+    "PausePlan",
+    "PauseSpec",
+]

--- a/omnivoice/__init__.py
+++ b/omnivoice/__init__.py
@@ -30,6 +30,7 @@ from omnivoice.narration import (
     NarrationController,
     NarrationPlan,
     NarrationResult,
+    narration_capabilities,
     parse_narration_controls,
 )
 
@@ -43,5 +44,6 @@ __all__ = [
     "NarrationController",
     "NarrationPlan",
     "NarrationResult",
+    "narration_capabilities",
     "parse_narration_controls",
 ]

--- a/omnivoice/controls.py
+++ b/omnivoice/controls.py
@@ -1,0 +1,210 @@
+"""Structured pause controls for OmniVoice generation."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class PauseSpec:
+    after_char: int
+    seconds: float
+
+
+@dataclass(frozen=True)
+class PausePlan:
+    pauses: tuple[PauseSpec, ...]
+
+
+@dataclass(frozen=True)
+class PauseLayout:
+    speech_frames: int
+    total_frames: int
+    phrase_frames: tuple[int, ...]
+    pause_frames: tuple[int, ...]
+
+
+_PAUSE_CANDIDATE_RE = re.compile(r"<pause:([^<>]*)>")
+_NUMBER_RE = re.compile(r"(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?\Z")
+
+
+def _validate_seconds(value: object) -> float:
+    if isinstance(value, bool):
+        raise ValueError("Pause duration must be a positive finite number")
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Pause duration must be a positive finite number") from exc
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError("Pause duration must be a positive finite number")
+    return seconds
+
+
+def canonicalize_pause_plan(text: str, plan: PausePlan) -> PausePlan:
+    """Validate, sort, and merge pauses that share an insertion offset."""
+    if not isinstance(plan, PausePlan):
+        raise TypeError("pause_plan items must be PausePlan or None")
+
+    merged: dict[int, float] = {}
+    for pause in plan.pauses:
+        if not isinstance(pause, PauseSpec):
+            raise TypeError("PausePlan.pauses must contain PauseSpec values")
+        if isinstance(pause.after_char, bool) or not isinstance(pause.after_char, int):
+            raise ValueError("Pause offset must be an integer")
+        if pause.after_char <= 0 or pause.after_char >= len(text):
+            raise ValueError("Leading and trailing pauses are not supported")
+        seconds = _validate_seconds(pause.seconds)
+        merged[pause.after_char] = merged.get(pause.after_char, 0.0) + seconds
+
+    pauses = tuple(PauseSpec(offset, merged[offset]) for offset in sorted(merged))
+    start = 0
+    for pause in pauses:
+        if not text[start : pause.after_char].strip():
+            raise ValueError("Pause offsets must separate nonempty phrases")
+        start = pause.after_char
+    if pauses and not text[start:].strip():
+        raise ValueError("Pause offsets must separate nonempty phrases")
+    return PausePlan(pauses)
+
+
+def parse_pause_markers(text: str) -> tuple[str, PausePlan]:
+    """Strip inline pause markers and return offsets in cleaned text."""
+    if not isinstance(text, str):
+        raise TypeError("text items must be strings")
+
+    matches = list(_PAUSE_CANDIDATE_RE.finditer(text))
+    residue = _PAUSE_CANDIDATE_RE.sub("", text)
+    if "<pause" in residue:
+        raise ValueError("Malformed <pause...> marker")
+    if not matches:
+        return text, PausePlan(())
+
+    durations = []
+    for match in matches:
+        raw = match.group(1)
+        if not _NUMBER_RE.fullmatch(raw) and raw.lower() not in {
+            "nan",
+            "inf",
+            "+inf",
+            "-inf",
+            "infinity",
+            "+infinity",
+            "-infinity",
+        }:
+            raise ValueError(f"Invalid pause duration: {raw!r}")
+        durations.append(_validate_seconds(raw))
+
+    segments: list[str] = []
+    cursor = 0
+    for match in matches:
+        segments.append(text[cursor : match.start()])
+        cursor = match.end()
+    segments.append(text[cursor:])
+
+    cleaned = segments[0]
+    pauses: list[PauseSpec] = []
+    i = 0
+    while i < len(matches):
+        seconds = durations[i]
+        j = i
+        while j + 1 < len(matches) and not segments[j + 1].strip():
+            j += 1
+            seconds += durations[j]
+
+        right = segments[j + 1]
+        had_whitespace = bool(cleaned and cleaned[-1].isspace()) or bool(
+            right and right[0].isspace()
+        )
+        cleaned = cleaned.rstrip()
+        if not cleaned:
+            raise ValueError("Leading pauses are not supported")
+        offset = len(cleaned)
+        right = right.lstrip()
+        if not right:
+            raise ValueError("Trailing pauses are not supported")
+
+        pauses.append(PauseSpec(offset, seconds))
+        if had_whitespace:
+            cleaned += " "
+        cleaned += right
+        i = j + 1
+
+    return cleaned, canonicalize_pause_plan(cleaned, PausePlan(tuple(pauses)))
+
+
+def pause_seconds_to_frames(seconds: float, frame_rate: int = 25) -> int:
+    """Convert seconds to codec frames using round-half-up semantics."""
+    seconds = _validate_seconds(seconds)
+    frames = math.floor(seconds * frame_rate + 0.5)
+    if frames < 1:
+        raise ValueError("Pause duration is shorter than one codec frame")
+    return frames
+
+
+def create_pause_layout(
+    text: str,
+    plan: PausePlan,
+    estimated_speech_frames: int,
+    speed: float,
+    duration: float | None,
+    frame_rate: int,
+    weight_fn: Callable[[str], float],
+) -> PauseLayout:
+    """Allocate speech phrases and fixed pause spans in codec-frame space."""
+    plan = canonicalize_pause_plan(text, plan)
+    if not plan.pauses:
+        raise ValueError("Pause layout requires at least one pause")
+    if not math.isfinite(speed) or speed <= 0:
+        raise ValueError("speed must be a positive finite number")
+
+    pause_frames = tuple(
+        pause_seconds_to_frames(pause.seconds, frame_rate) for pause in plan.pauses
+    )
+    if duration is None:
+        speech_frames = max(1, int(estimated_speech_frames / speed))
+        total_frames = speech_frames + sum(pause_frames)
+    else:
+        if not math.isfinite(duration) or duration <= 0:
+            raise ValueError("duration must be a positive finite number")
+        total_frames = max(1, int(duration * frame_rate))
+        speech_frames = total_frames - sum(pause_frames)
+
+    offsets = [0, *(pause.after_char for pause in plan.pauses), len(text)]
+    phrases = [text[offsets[i] : offsets[i + 1]] for i in range(len(offsets) - 1)]
+    phrase_count = len(phrases)
+    if speech_frames < phrase_count:
+        raise ValueError(
+            "duration leaves fewer than one speech frame per nonempty phrase"
+        )
+
+    weights = [max(0.0, float(weight_fn(phrase))) for phrase in phrases]
+    total_weight = sum(weights)
+    if total_weight <= 0:
+        weights = [1.0] * phrase_count
+        total_weight = float(phrase_count)
+
+    boundaries: list[int] = []
+    previous = 0
+    cumulative = 0.0
+    for i, weight in enumerate(weights[:-1]):
+        cumulative += weight
+        proposed = math.floor(speech_frames * cumulative / total_weight + 0.5)
+        remaining_phrases = phrase_count - i - 1
+        boundary = max(previous + 1, proposed)
+        boundary = min(boundary, speech_frames - remaining_phrases)
+        boundaries.append(boundary)
+        previous = boundary
+
+    speech_boundaries = [0, *boundaries, speech_frames]
+    phrase_frames = tuple(
+        speech_boundaries[i + 1] - speech_boundaries[i] for i in range(phrase_count)
+    )
+    return PauseLayout(
+        speech_frames=speech_frames,
+        total_frames=total_frames,
+        phrase_frames=phrase_frames,
+        pause_frames=pause_frames,
+    )

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -1372,7 +1372,10 @@ class OmniVoice(PreTrainedModel):
         }
 
     def _generate_iterative(
-        self, task: GenerationTask, gen_config: OmniVoiceGenerationConfig
+        self,
+        task: GenerationTask,
+        gen_config: OmniVoiceGenerationConfig,
+        trace: Optional[list[dict]] = None,
     ) -> List[torch.Tensor]:
         """N-step iterative unmasked decoding.
 
@@ -1492,6 +1495,43 @@ class OmniVoice(PreTrainedModel):
         fixed_checks = torch.ones(
             (gen_config.num_step, B), dtype=torch.bool, device=self.device
         )
+        trace_items = None
+        if trace is not None:
+            trace_items = []
+            for i, t_len in enumerate(task.target_lens):
+                template = task.target_templates[i] if task.target_templates else None
+                fixed = (
+                    torch.zeros(
+                        (self.config.num_audio_codebook, t_len),
+                        dtype=torch.bool,
+                        device=self.device,
+                    )
+                    if template is None
+                    else template != self.config.audio_mask_id
+                )
+                pause = torch.zeros_like(fixed)
+                if task.pause_spans is not None:
+                    for start, end in task.pause_spans[i]:
+                        pause[:, start:end] = True
+                shape = (self.config.num_audio_codebook, t_len)
+                trace_items.append(
+                    {
+                        "unmask_step": torch.full(
+                            shape, -1, dtype=torch.int16, device=self.device
+                        ),
+                        "token_logprob": torch.full(
+                            shape, float("nan"), dtype=torch.float32, device=self.device
+                        ),
+                        "entropy": torch.full(
+                            shape, float("nan"), dtype=torch.float32, device=self.device
+                        ),
+                        "cfg_delta": torch.full(
+                            shape, float("nan"), dtype=torch.float32, device=self.device
+                        ),
+                        "fixed": fixed,
+                        "pause": pause,
+                    }
+                )
 
         for step in range(gen_config.num_step):
             if not any(schedules[i][step] > 0 for i in range(B)):
@@ -1514,9 +1554,15 @@ class OmniVoice(PreTrainedModel):
                 c_logits = batch_logits[i : i + 1, :, c_len - t_len : c_len, :]
                 u_logits = batch_logits[B + i : B + i + 1, :, :t_len, :]
 
-                pred_tokens, scores = self._predict_tokens_with_scoring(
-                    c_logits, u_logits, gen_config
-                )
+                diagnostics = None
+                if trace_items is None:
+                    pred_tokens, scores = self._predict_tokens_with_scoring(
+                        c_logits, u_logits, gen_config
+                    )
+                else:
+                    pred_tokens, scores, diagnostics = self._predict_tokens_with_scoring(
+                        c_logits, u_logits, gen_config, return_diagnostics=True
+                    )
 
                 scores = scores - (layer_ids * gen_config.layer_penalty_factor)
 
@@ -1539,6 +1585,33 @@ class OmniVoice(PreTrainedModel):
                 flat_tokens[topk_idx] = pred_tokens.flatten()[topk_idx]
                 sample_tokens.copy_(flat_tokens.view_as(sample_tokens))
 
+                if diagnostics is not None:
+                    chosen = pred_tokens.flatten()[topk_idx]
+                    combined = diagnostics["log_probs"].view(-1, c_logits.shape[-1])[
+                        topk_idx
+                    ]
+                    conditional = diagnostics["c_log_probs"].view(
+                        -1, c_logits.shape[-1]
+                    )[topk_idx]
+                    unconditional = diagnostics["u_log_probs"].view(
+                        -1, c_logits.shape[-1]
+                    )[topk_idx]
+                    row = torch.arange(k, device=self.device)
+                    chosen_logprob = combined[row, chosen]
+                    probability = combined.exp()
+                    entropy = -(
+                        probability
+                        * torch.where(
+                            torch.isfinite(combined), combined, torch.zeros_like(combined)
+                        )
+                    ).sum(dim=-1)
+                    cfg_delta = conditional[row, chosen] - unconditional[row, chosen]
+                    item = trace_items[i]
+                    item["unmask_step"].view(-1)[topk_idx] = step + 1
+                    item["token_logprob"].view(-1)[topk_idx] = chosen_logprob
+                    item["entropy"].view(-1)[topk_idx] = entropy
+                    item["cfg_delta"].view(-1)[topk_idx] = cfg_delta
+
                 # Update individual slices into batched structure
                 tokens[i : i + 1, :, :t_len] = sample_tokens
                 batch_input_ids[i : i + 1, :, c_len - t_len : c_len] = sample_tokens
@@ -1560,9 +1633,29 @@ class OmniVoice(PreTrainedModel):
                 f"Fixed pause token mutated at diffusion step {int(first[0].item()) + 1}"
             )
 
+        if trace_items is not None:
+            for i, item in enumerate(trace_items):
+                trace.append(
+                    {
+                        "format": "omnivoice_generation_trace_v1",
+                        "num_step": gen_config.num_step,
+                        "frame_rate": self.audio_tokenizer.config.frame_rate,
+                        "codebook_weights": tuple(self.config.audio_codebook_weights),
+                        "tokens": tokens[i, :, : task.target_lens[i]].detach().cpu(),
+                        "unmask_step": item["unmask_step"].detach().cpu(),
+                        "token_logprob": item["token_logprob"].detach().cpu(),
+                        "entropy": item["entropy"].detach().cpu(),
+                        "cfg_delta": item["cfg_delta"].detach().cpu(),
+                        "fixed": item["fixed"].detach().cpu(),
+                        "pause": item["pause"].detach().cpu(),
+                    }
+                )
+
         return [tokens[i, :, : task.target_lens[i]] for i in range(B)]
 
-    def _predict_tokens_with_scoring(self, c_logits, u_logits, gen_config):
+    def _predict_tokens_with_scoring(
+        self, c_logits, u_logits, gen_config, return_diagnostics: bool = False
+    ):
         if gen_config.guidance_scale != 0:
             c_log_probs = F.log_softmax(c_logits, dim=-1)
             u_log_probs = F.log_softmax(u_logits, dim=-1)
@@ -1571,7 +1664,13 @@ class OmniVoice(PreTrainedModel):
                 dim=-1,
             )
         else:
-            log_probs = F.log_softmax(c_logits, dim=-1)
+            c_log_probs = F.log_softmax(c_logits, dim=-1)
+            log_probs = c_log_probs
+            u_log_probs = (
+                F.log_softmax(u_logits, dim=-1)
+                if return_diagnostics
+                else None
+            )
 
         log_probs[..., self.config.audio_mask_id] = -float("inf")
 
@@ -1585,6 +1684,12 @@ class OmniVoice(PreTrainedModel):
 
         confidence_scores = log_probs.max(dim=-1)[0]
 
+        if return_diagnostics:
+            return pred_tokens, confidence_scores, {
+                "log_probs": log_probs,
+                "c_log_probs": c_log_probs,
+                "u_log_probs": u_log_probs,
+            }
         return pred_tokens, confidence_scores
 
 

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -59,6 +59,12 @@ from transformers import (
 from transformers.modeling_outputs import ModelOutput
 from transformers.models.auto import CONFIG_MAPPING, AutoConfig
 
+from omnivoice.controls import (
+    PausePlan,
+    canonicalize_pause_plan,
+    create_pause_layout,
+    parse_pause_markers,
+)
 from omnivoice.utils.audio import (
     cross_fade_chunks,
     fade_and_pad_audio,
@@ -128,6 +134,9 @@ class GenerationTask:
     ref_audio_tokens: List[Optional[torch.Tensor]]
     ref_rms: List[Optional[float]]
     speed: Optional[List[float]] = None
+    target_templates: Optional[List[Optional[torch.Tensor]]] = None
+    pause_spans: Optional[List[tuple[tuple[int, int], ...]]] = None
+    controlled: Optional[List[bool]] = None
 
     def get_indices(self, config: OmniVoiceGenerationConfig, frame_rate: int):
         threshold = int(config.audio_chunk_threshold * frame_rate)
@@ -148,6 +157,21 @@ class GenerationTask:
             ref_audio_tokens=[self.ref_audio_tokens[i] for i in indices],
             ref_rms=[self.ref_rms[i] for i in indices],
             speed=[self.speed[i] for i in indices] if self.speed else None,
+            target_templates=(
+                [self.target_templates[i] for i in indices]
+                if self.target_templates is not None
+                else None
+            ),
+            pause_spans=(
+                [self.pause_spans[i] for i in indices]
+                if self.pause_spans is not None
+                else None
+            ),
+            controlled=(
+                [self.controlled[i] for i in indices]
+                if self.controlled is not None
+                else None
+            ),
         )
 
 
@@ -493,6 +517,8 @@ class OmniVoice(PreTrainedModel):
         duration: Union[float, list[Optional[float]], None] = None,
         speed: Union[float, list[Optional[float]], None] = None,
         generation_config: Optional[OmniVoiceGenerationConfig] = None,
+        pause_plan: Union[PausePlan, list[Optional[PausePlan]], None] = None,
+        pause_audio: Union[str, tuple[torch.Tensor, int], None] = None,
         **kwargs,
     ) -> list[np.ndarray]:
         """Generate speech audio given text in various modes.
@@ -526,6 +552,12 @@ class OmniVoice(PreTrainedModel):
                 the model's default estimation.
             generation_config: Explicit config object. If provided, takes
                 precedence over ``**kwargs``.
+            pause_plan: Structured pause controls. Batch input requires one
+                plan or ``None`` per text item. Inline ``<pause:0.60>`` markers
+                are also supported, but cannot be combined with a structured
+                plan for the same item.
+            pause_audio: Optional shared room-tone audio used to encode fixed
+                pause tokens. ``None`` encodes digital silence.
             **kwargs: Generation config or its fields:
                 denoise: Whether to prepend the ``<|denoise|>`` token.
                 num_step: Number of iterative decoding steps.
@@ -574,11 +606,17 @@ class OmniVoice(PreTrainedModel):
             preprocess_prompt=gen_config.preprocess_prompt,
             speed=speed,
             duration=duration,
+            pause_plan=pause_plan,
+            pause_audio=pause_audio,
         )
 
         short_idx, long_idx = full_task.get_indices(
             gen_config, self.audio_tokenizer.config.frame_rate
         )
+        if full_task.controlled and any(full_task.controlled[i] for i in long_idx):
+            raise ValueError(
+                "Pause-controlled generation supports short-form items only"
+            )
 
         results = [None] * full_task.batch_size
 
@@ -602,6 +640,9 @@ class OmniVoice(PreTrainedModel):
                     results[i],
                     full_task.ref_rms[i],
                     gen_config,  # type: ignore[arg-type]
+                    preserve_internal_silence=(
+                        full_task.controlled[i] if full_task.controlled else False
+                    ),
                 )
             )
 
@@ -717,6 +758,7 @@ class OmniVoice(PreTrainedModel):
         tokens: Union[torch.Tensor, List[torch.Tensor]],
         rms: Union[float, None],
         gen_config: OmniVoiceGenerationConfig,
+        preserve_internal_silence: bool = False,
     ) -> np.ndarray:
         """
         Args:
@@ -749,6 +791,7 @@ class OmniVoice(PreTrainedModel):
             audio_waveform,
             ref_rms=rms,
             gen_config=gen_config,
+            preserve_internal_silence=preserve_internal_silence,
         )
         return audio_waveform.squeeze(0)
 
@@ -757,6 +800,7 @@ class OmniVoice(PreTrainedModel):
         generated_audio: np.ndarray,
         ref_rms: Union[float, None],
         gen_config: OmniVoiceGenerationConfig,
+        preserve_internal_silence: bool = False,
     ) -> np.ndarray:
         """Optionally remove long silences, adjust volume, and add edge padding.
 
@@ -771,7 +815,7 @@ class OmniVoice(PreTrainedModel):
             generated_audio = remove_silence(
                 generated_audio,
                 self.sampling_rate,
-                mid_sil=500,
+                mid_sil=0 if preserve_internal_silence else 500,
                 lead_sil=100,
                 trail_sil=100,
             )
@@ -921,7 +965,10 @@ class OmniVoice(PreTrainedModel):
         preprocess_prompt: bool = True,
         speed: Union[float, list[Optional[float]], None] = None,
         duration: Union[float, list[Optional[float]], None] = None,
+        pause_plan: Union[PausePlan, list[Optional[PausePlan]], None] = None,
+        pause_audio: Union[str, tuple[torch.Tensor, int], None] = None,
     ) -> GenerationTask:
+        text_is_batch = not isinstance(text, str)
         if isinstance(text, str):
             text_list = [text]
         else:
@@ -930,6 +977,25 @@ class OmniVoice(PreTrainedModel):
             )
             text_list = text
         batch_size = len(text_list)
+
+        explicit_plans = self._normalize_pause_plans(
+            pause_plan, batch_size, text_is_batch
+        )
+        selected_plans: list[Optional[PausePlan]] = []
+        cleaned_texts: list[str] = []
+        for i, item_text in enumerate(text_list):
+            cleaned_text, inline_plan = parse_pause_markers(item_text)
+            explicit_plan = explicit_plans[i]
+            if inline_plan.pauses and explicit_plan is not None:
+                raise ValueError(
+                    "Cannot combine inline pause markers and pause_plan for one item"
+                )
+            if explicit_plan is not None:
+                explicit_plan = canonicalize_pause_plan(cleaned_text, explicit_plan)
+            selected_plan = inline_plan if inline_plan.pauses else explicit_plan
+            cleaned_texts.append(cleaned_text)
+            selected_plans.append(selected_plan)
+        text_list = cleaned_texts
 
         language_list = self._ensure_list(language, batch_size)
         language_list = [_resolve_language(lang) for lang in language_list]
@@ -981,6 +1047,8 @@ class OmniVoice(PreTrainedModel):
                 user_speed = [float(speed)] * batch_size
             else:
                 user_speed = list(speed)
+                if len(user_speed) != batch_size:
+                    raise ValueError("speed list must match text batch size")
         else:
             user_speed = None
 
@@ -989,33 +1057,59 @@ class OmniVoice(PreTrainedModel):
                 durations = [float(duration)] * batch_size
             else:
                 durations = list(duration)
+                if len(durations) != batch_size:
+                    raise ValueError("duration list must match text batch size")
         else:
             durations = None
 
+        frame_rate = self.audio_tokenizer.config.frame_rate
         num_target_tokens_list = []
+        pause_layouts = []
         for i in range(batch_size):
-            # duration[i] overrides speed for estimation: use speed=1.0
-            # to get the raw estimate, then override target_lens below.
             has_dur = durations is not None and durations[i] is not None
-            item_speed = 1.0 if has_dur else (user_speed[i] if user_speed else 1.0)
+            item_speed = (
+                user_speed[i] if user_speed and user_speed[i] is not None else 1.0
+            )
+            plan = selected_plans[i]
+            controlled = bool(plan and plan.pauses)
+            estimate_speed = 1.0 if has_dur or controlled else item_speed
             est = self._estimate_target_tokens(
                 text_list[i],
                 ref_text_list[i],
                 ref_audio_tokens_list[i].size(-1)
                 if ref_audio_tokens_list[i] is not None
                 else None,
-                speed=item_speed,
+                speed=estimate_speed,
             )
-            num_target_tokens_list.append(est)
+            if controlled:
+                layout = create_pause_layout(
+                    text=text_list[i],
+                    plan=plan,
+                    estimated_speech_frames=est,
+                    speed=item_speed,
+                    duration=durations[i] if has_dur else None,
+                    frame_rate=frame_rate,
+                    weight_fn=self.duration_estimator.calculate_total_weight,
+                )
+                num_target_tokens_list.append(layout.total_frames)
+                pause_layouts.append(layout)
+            else:
+                num_target_tokens_list.append(est)
+                pause_layouts.append(None)
 
         # Per-item duration overrides: set target_lens to exact frame count
         # and compute speed ratio so chunked generation scales proportionally.
         speed_list: Optional[List[float]] = None
         if durations is not None:
-            frame_rate = self.audio_tokenizer.config.frame_rate
             speed_list = []
             for i in range(batch_size):
-                if durations[i] is not None:
+                if pause_layouts[i] is not None:
+                    speed_list.append(
+                        user_speed[i]
+                        if user_speed and user_speed[i] is not None
+                        else 1.0
+                    )
+                elif durations[i] is not None:
                     target_tokens = max(1, int(durations[i] * frame_rate))
                     est = num_target_tokens_list[i]
                     speed_list.append(est / target_tokens if target_tokens > 0 else 1.0)
@@ -1025,6 +1119,25 @@ class OmniVoice(PreTrainedModel):
                     speed_list.append(s if s is not None else 1.0)
         elif user_speed is not None:
             speed_list = [s if s is not None else 1.0 for s in user_speed]
+
+        target_templates: list[Optional[torch.Tensor]] = [None] * batch_size
+        pause_spans: list[tuple[tuple[int, int], ...]] = [()] * batch_size
+        pause_token_cache: dict[int, torch.Tensor] = {}
+        pause_source = None
+        controlled_layouts = [layout for layout in pause_layouts if layout is not None]
+        if controlled_layouts and pause_audio is not None:
+            longest_pause = max(
+                frame_count
+                for layout in controlled_layouts
+                for frame_count in layout.pause_frames
+            )
+            pause_source = self._load_pause_source(pause_audio, longest_pause)
+        for i, layout in enumerate(pause_layouts):
+            if layout is None:
+                continue
+            target_templates[i], pause_spans[i] = self._create_pause_template(
+                layout, pause_source, pause_token_cache
+            )
 
         return GenerationTask(
             batch_size=batch_size,
@@ -1036,7 +1149,113 @@ class OmniVoice(PreTrainedModel):
             ref_audio_tokens=ref_audio_tokens_list,
             ref_rms=ref_rms_list,
             speed=speed_list,
+            target_templates=target_templates,
+            pause_spans=pause_spans,
+            controlled=[layout is not None for layout in pause_layouts],
         )
+
+    def _normalize_pause_plans(
+        self,
+        pause_plan: Union[PausePlan, list[Optional[PausePlan]], None],
+        batch_size: int,
+        text_is_batch: bool,
+    ) -> list[Optional[PausePlan]]:
+        if pause_plan is None:
+            return [None] * batch_size
+        if isinstance(pause_plan, PausePlan):
+            if text_is_batch:
+                raise ValueError(
+                    "Batch text requires a pause_plan list matching batch size"
+                )
+            return [pause_plan]
+        if not isinstance(pause_plan, list) or len(pause_plan) != batch_size:
+            raise ValueError("pause_plan list must match text batch size")
+        if any(
+            item is not None and not isinstance(item, PausePlan) for item in pause_plan
+        ):
+            raise TypeError("pause_plan items must be PausePlan or None")
+        return list(pause_plan)
+
+    def _load_pause_source(
+        self,
+        pause_audio: Union[str, tuple[torch.Tensor, int]],
+        longest_pause_frames: int,
+    ) -> torch.Tensor:
+        if isinstance(pause_audio, str):
+            waveform = torch.from_numpy(load_audio(pause_audio, self.sampling_rate))
+        else:
+            waveform, sample_rate = pause_audio
+            waveform = torch.as_tensor(waveform).detach().cpu().to(torch.float32)
+            if waveform.ndim == 1:
+                waveform = waveform.unsqueeze(0)
+            if waveform.ndim != 2:
+                raise ValueError("pause_audio waveform must be one- or two-dimensional")
+            if waveform.size(0) > 1:
+                waveform = waveform.mean(dim=0, keepdim=True)
+            if sample_rate != self.sampling_rate:
+                waveform = torchaudio.functional.resample(
+                    waveform, orig_freq=sample_rate, new_freq=self.sampling_rate
+                )
+        waveform = waveform.to(torch.float32)
+        if not torch.isfinite(waveform).all():
+            raise ValueError("pause_audio contains nonfinite samples")
+        required_samples = longest_pause_frames * 960
+        if waveform.shape[-1] < required_samples:
+            raise ValueError("pause_audio is shorter than the longest requested pause")
+        return waveform
+
+    def _encode_pause_tokens(
+        self,
+        pause_frames: int,
+        pause_source: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        num_samples = pause_frames * 960
+        if pause_source is None:
+            waveform = torch.zeros((1, num_samples), dtype=torch.float32)
+        else:
+            start = (pause_source.shape[-1] - num_samples) // 2
+            waveform = pause_source[:, start : start + num_samples]
+        tokens = self.audio_tokenizer.encode(
+            waveform.to(self.audio_tokenizer.device).unsqueeze(0)
+        ).audio_codes.squeeze(0)
+        expected_shape = (self.config.num_audio_codebook, pause_frames)
+        if tuple(tokens.shape) != expected_shape:
+            raise RuntimeError(
+                f"Pause tokenizer returned {tuple(tokens.shape)}, expected {expected_shape}"
+            )
+        if torch.any(tokens == self.config.audio_mask_id):
+            raise RuntimeError("Pause tokenizer returned audio mask tokens")
+        return tokens.to(self.device)
+
+    def _create_pause_template(
+        self,
+        layout,
+        pause_source: Optional[torch.Tensor],
+        cache: dict[int, torch.Tensor],
+    ) -> tuple[torch.Tensor, tuple[tuple[int, int], ...]]:
+        template = torch.full(
+            (self.config.num_audio_codebook, layout.total_frames),
+            self.config.audio_mask_id,
+            dtype=torch.long,
+            device=self.device,
+        )
+        spans = []
+        cursor = 0
+        for phrase_frames, pause_frames in zip(
+            layout.phrase_frames[:-1], layout.pause_frames
+        ):
+            cursor += phrase_frames
+            end = cursor + pause_frames
+            if pause_frames not in cache:
+                cache[pause_frames] = self._encode_pause_tokens(
+                    pause_frames, pause_source
+                )
+            template[:, cursor:end] = cache[pause_frames]
+            spans.append((cursor, end))
+            cursor = end
+        cursor += layout.phrase_frames[-1]
+        assert cursor == layout.total_frames
+        return template, tuple(spans)
 
     def _estimate_target_tokens(self, text, ref_text, num_ref_audio_tokens, speed=1.0):
         """Estimate number of target audio tokens."""
@@ -1076,6 +1295,7 @@ class OmniVoice(PreTrainedModel):
         lang: Optional[str] = None,
         instruct: Optional[str] = None,
         denoise: bool = True,
+        target_template: Optional[torch.Tensor] = None,
     ):
         """Prepare input_ids and audio masks for inference.
         Args:
@@ -1114,13 +1334,20 @@ class OmniVoice(PreTrainedModel):
             .unsqueeze(0)
         ).to(self.device)  # [1, C, N2]
 
-        # Target: all MASK
-        target_audio_tokens = torch.full(
-            (1, self.config.num_audio_codebook, num_target_tokens),
-            self.config.audio_mask_id,
-            dtype=torch.long,
-            device=self.device,
-        )
+        if target_template is None:
+            target_audio_tokens = torch.full(
+                (1, self.config.num_audio_codebook, num_target_tokens),
+                self.config.audio_mask_id,
+                dtype=torch.long,
+                device=self.device,
+            )
+        else:
+            expected_shape = (self.config.num_audio_codebook, num_target_tokens)
+            if tuple(target_template.shape) != expected_shape:
+                raise ValueError(
+                    f"Target template has {tuple(target_template.shape)}, expected {expected_shape}"
+                )
+            target_audio_tokens = target_template.to(self.device).unsqueeze(0)
 
         # Conditional input
         parts = [style_tokens, text_tokens]
@@ -1181,6 +1408,7 @@ class OmniVoice(PreTrainedModel):
                 task.langs[i],
                 task.instructs[i],
                 gen_config.denoise,
+                task.target_templates[i] if task.target_templates else None,
             )
             for i in range(B)
         ]
@@ -1224,6 +1452,10 @@ class OmniVoice(PreTrainedModel):
             dtype=torch.long,
             device=self.device,
         )
+        if task.target_templates is not None:
+            for i, template in enumerate(task.target_templates):
+                if template is not None:
+                    tokens[i, :, : task.target_lens[i]] = template
 
         timesteps = _get_time_steps(
             t_start=0.0,
@@ -1232,8 +1464,13 @@ class OmniVoice(PreTrainedModel):
             t_shift=gen_config.t_shift,
         ).tolist()
         schedules = []
-        for t_len in task.target_lens:
-            total_mask = t_len * self.config.num_audio_codebook
+        for i, t_len in enumerate(task.target_lens):
+            template = task.target_templates[i] if task.target_templates else None
+            total_mask = (
+                t_len * self.config.num_audio_codebook
+                if template is None
+                else int((template == self.config.audio_mask_id).sum().item())
+            )
             rem = total_mask
             sched = []
             for step in range(gen_config.num_step):
@@ -1252,8 +1489,13 @@ class OmniVoice(PreTrainedModel):
         layer_ids = torch.arange(
             self.config.num_audio_codebook, device=self.device
         ).view(1, -1, 1)
+        fixed_checks = torch.ones(
+            (gen_config.num_step, B), dtype=torch.bool, device=self.device
+        )
 
         for step in range(gen_config.num_step):
+            if not any(schedules[i][step] > 0 for i in range(B)):
+                continue
             batch_logits = self(
                 input_ids=batch_input_ids,
                 audio_mask=batch_audio_mask,
@@ -1286,6 +1528,12 @@ class OmniVoice(PreTrainedModel):
                     sample_tokens != self.config.audio_mask_id, -float("inf")
                 )
 
+                remaining_masks = int(
+                    (sample_tokens == self.config.audio_mask_id).sum().item()
+                )
+                k = min(k, remaining_masks)
+                if k <= 0:
+                    continue
                 _, topk_idx = torch.topk(scores.flatten(), k)
                 flat_tokens = sample_tokens.flatten()
                 flat_tokens[topk_idx] = pred_tokens.flatten()[topk_idx]
@@ -1295,6 +1543,22 @@ class OmniVoice(PreTrainedModel):
                 tokens[i : i + 1, :, :t_len] = sample_tokens
                 batch_input_ids[i : i + 1, :, c_len - t_len : c_len] = sample_tokens
                 batch_input_ids[B + i : B + i + 1, :, :t_len] = sample_tokens
+
+            if task.target_templates is not None:
+                for i, template in enumerate(task.target_templates):
+                    if template is None:
+                        continue
+                    t_len = task.target_lens[i]
+                    fixed = template != self.config.audio_mask_id
+                    fixed_checks[step, i] = torch.all(
+                        tokens[i, :, :t_len][fixed] == template[fixed]
+                    )
+
+        if not bool(fixed_checks.all().item()):
+            first = torch.nonzero(~fixed_checks, as_tuple=False)[0]
+            raise RuntimeError(
+                f"Fixed pause token mutated at diffusion step {int(first[0].item()) + 1}"
+            )
 
         return [tokens[i, :, : task.target_lens[i]] for i in range(B)]
 

--- a/omnivoice/narration.py
+++ b/omnivoice/narration.py
@@ -49,6 +49,7 @@ class NarrationResult:
     tokens: torch.Tensor
     baseline_tokens: torch.Tensor
     report: dict[str, Any]
+    traces: Optional[dict[str, Any]] = None
 
 
 _CONTROL_TAG_RE = re.compile(
@@ -105,6 +106,37 @@ _CMU_CONSONANTS = {
     "Z",
     "ZH",
 }
+
+NARRATION_CAPABILITIES = {
+    "format": "omnivoice_narration_capabilities_v1",
+    "frame_rate": 25,
+    "short_form_only": True,
+    "regional_controls": {
+        "emphasis": {"values": ["reduced", "moderate", "strong"]},
+        "rate": {"min": 0.7, "max": 1.4, "step": 0.05},
+        "intonation": {"values": ["rising", "falling"]},
+        "aside": {"values": ["parenthetical"]},
+    },
+    "pause": {"min_seconds": 0.04, "max_seconds": 5.0, "frame_seconds": 0.04},
+    "trace": {
+        "format": "omnivoice_generation_trace_v1",
+        "fields": [
+            "unmask_step",
+            "token_logprob",
+            "entropy",
+            "cfg_delta",
+            "fixed",
+            "pause",
+        ],
+    },
+}
+
+
+def narration_capabilities() -> dict[str, Any]:
+    """Return stable controls/trace schema without loading model weights."""
+    import copy
+
+    return copy.deepcopy(NARRATION_CAPABILITIES)
 
 
 def _expand_shorthand(text: str) -> str:
@@ -213,33 +245,50 @@ def _normalize_cmu_pronunciation(value: str) -> str:
 
 def _resolve_pronunciations(
     plan: NarrationPlan, pronunciations: Optional[dict[str, str]]
-) -> dict[int, str]:
+) -> dict[int, str | tuple[tuple[int, int, str], ...]]:
     if pronunciations is None:
         return {}
     if not isinstance(pronunciations, dict):
         raise TypeError("pronunciations must be a dictionary")
 
-    surfaces: dict[str, list[int]] = {}
-    for index, control in enumerate(plan.controls):
-        surface = plan.text[control.start_char : control.end_char].strip().casefold()
-        surfaces.setdefault(surface, []).append(index)
-
-    resolved = {}
+    resolved_parts: dict[int, list[tuple[int, int, str]]] = {}
     seen_keys = set()
-    for raw_key, raw_value in pronunciations.items():
+    ordered = sorted(
+        pronunciations.items(), key=lambda item: len(str(item[0]).strip()), reverse=True
+    )
+    for raw_key, raw_value in ordered:
         if not isinstance(raw_key, str) or not raw_key.strip():
             raise TypeError("pronunciation keys must be nonempty strings")
         key = raw_key.strip().casefold()
         if key in seen_keys:
             raise ValueError(f"Duplicate pronunciation key: {raw_key!r}")
         seen_keys.add(key)
-        if key not in surfaces:
+        pronunciation = _normalize_cmu_pronunciation(raw_value)
+        matched = False
+        pattern = re.compile(r"(?<![A-Za-z0-9'])" + re.escape(key) + r"(?![A-Za-z0-9'])")
+        for control_index, control in enumerate(plan.controls):
+            surface = plan.text[control.start_char : control.end_char]
+            for match in pattern.finditer(surface.casefold()):
+                parts = resolved_parts.setdefault(control_index, [])
+                start, end = match.span()
+                if any(start < old_end and old_start < end for old_start, old_end, _ in parts):
+                    continue
+                parts.append((start, end, pronunciation))
+                matched = True
+        if not matched:
             raise ValueError(
                 f"Pronunciation key does not match a controlled span: {raw_key!r}"
             )
-        pronunciation = _normalize_cmu_pronunciation(raw_value)
-        for control_index in surfaces[key]:
-            resolved[control_index] = pronunciation
+
+    resolved: dict[int, str | tuple[tuple[int, int, str], ...]] = {}
+    for control_index, parts in resolved_parts.items():
+        control = plan.controls[control_index]
+        surface = plan.text[control.start_char : control.end_char]
+        parts.sort(key=lambda item: item[0])
+        if len(parts) == 1 and parts[0][0] == 0 and parts[0][1] == len(surface):
+            resolved[control_index] = parts[0][2]
+        else:
+            resolved[control_index] = tuple(parts)
     return resolved
 
 
@@ -394,12 +443,23 @@ def build_inpaint_template(
 def _conditioned_text(
     text: str,
     control: NarrationControl,
-    pronunciation: Optional[str] = None,
+    pronunciation: Optional[str | tuple[tuple[int, int, str], ...]] = None,
 ) -> str:
     before = text[: control.start_char]
     surface = text[control.start_char : control.end_char]
     after = text[control.end_char :]
-    spoken = pronunciation or surface
+    if isinstance(pronunciation, str):
+        spoken = pronunciation
+    elif pronunciation:
+        pieces = []
+        cursor = 0
+        for start, end, replacement in pronunciation:
+            pieces.extend((surface[cursor:start], replacement))
+            cursor = end
+        pieces.append(surface[cursor:])
+        spoken = "".join(pieces)
+    else:
+        spoken = surface
     if control.kind == "emphasis":
         if control.value == "reduced":
             replacement = f"({spoken})"
@@ -689,7 +749,6 @@ class NarrationController:
         task.controlled = [True]
         return task
 
-    @torch.inference_mode()
     def generate(
         self,
         text: str,
@@ -704,10 +763,43 @@ class NarrationController:
         seed: int = 1234,
         preprocess_prompt: bool = True,
         pronunciations: Optional[dict[str, str]] = None,
+        trace: bool = False,
     ) -> NarrationResult:
+        plan = parse_narration_controls(text, shorthand=shorthand)
+        return self.generate_plan(
+            plan,
+            ref_audio=ref_audio,
+            ref_text=ref_text,
+            voice_clone_prompt=voice_clone_prompt,
+            language=language,
+            num_step=num_step,
+            candidates=candidates,
+            seed=seed,
+            preprocess_prompt=preprocess_prompt,
+            pronunciations=pronunciations,
+            trace=trace,
+        )
+
+    @torch.inference_mode()
+    def generate_plan(
+        self,
+        plan: NarrationPlan,
+        *,
+        ref_audio=None,
+        ref_text: Optional[str] = None,
+        voice_clone_prompt: Optional[VoiceClonePrompt] = None,
+        language: Optional[str] = "English",
+        num_step: int = 32,
+        candidates: int = 3,
+        seed: int = 1234,
+        preprocess_prompt: bool = True,
+        pronunciations: Optional[dict[str, str]] = None,
+        trace: bool = False,
+    ) -> NarrationResult:
+        if not isinstance(plan, NarrationPlan):
+            raise TypeError("plan must be a NarrationPlan")
         if candidates < 1:
             raise ValueError("candidates must be at least 1")
-        plan = parse_narration_controls(text, shorthand=shorthand)
         resolved_pronunciations = _resolve_pronunciations(plan, pronunciations)
         prompt = self._resolve_prompt(
             voice_clone_prompt, ref_audio, ref_text, preprocess_prompt
@@ -731,7 +823,10 @@ class NarrationController:
         )
         if long_idx or short_idx != [0]:
             raise ValueError("Narration controls support one short-form item only")
-        baseline_tokens = self.model._generate_iterative(baseline_task, config)[0]
+        baseline_trace = [] if trace else None
+        baseline_tokens = self.model._generate_iterative(
+            baseline_task, config, trace=baseline_trace
+        )[0]
         baseline_raw = _decode_tokens(self.model, baseline_tokens)
         baseline_audio = self.model._decode_and_post_process(
             baseline_tokens,
@@ -745,6 +840,7 @@ class NarrationController:
         pause_spans = baseline_task.pause_spans[0]
         expected_words = normalized_words(plan.text)
         control_reports = []
+        selected_traces = []
         frame_rate = self.model.audio_tokenizer.config.frame_rate
 
         for control_index, control in enumerate(plan.controls):
@@ -815,7 +911,10 @@ class NarrationController:
                     template,
                     pause_spans,
                 )
-                candidate_tokens = self.model._generate_iterative(task, config)[0]
+                candidate_trace = [] if trace else None
+                candidate_tokens = self.model._generate_iterative(
+                    task, config, trace=candidate_trace
+                )[0]
                 fixed = template != self.model.config.audio_mask_id
                 fixed_tokens_unchanged = bool(
                     torch.equal(candidate_tokens[fixed], template[fixed])
@@ -844,7 +943,13 @@ class NarrationController:
                 }
                 candidate_reports.append(candidate_report)
                 if best is None or score > best[0]:
-                    best = (score, candidate_tokens, candidate_raw, candidate_index)
+                    best = (
+                        score,
+                        candidate_tokens,
+                        candidate_raw,
+                        candidate_index,
+                        candidate_trace[0] if candidate_trace else None,
+                    )
 
             assert best is not None
             current_tokens = best[1]
@@ -864,6 +969,9 @@ class NarrationController:
                     "candidates": candidate_reports,
                 }
             )
+            if trace:
+                control_reports[-1]["selected_trace_index"] = control_index
+                selected_traces.append(best[4])
 
         final_audio = self.model._decode_and_post_process(
             current_tokens,
@@ -874,19 +982,29 @@ class NarrationController:
         final_transcript = _transcribe(
             self.aligner, current_raw, self.model.sampling_rate
         )
+        pronunciation_report = {}
+        for index, value in resolved_pronunciations.items():
+            surface = plan.text[
+                plan.controls[index].start_char : plan.controls[index].end_char
+            ]
+            if isinstance(value, str):
+                pronunciation_report[surface] = value
+            else:
+                pronunciation_report[surface] = [
+                    {
+                        "surface": surface[start:end],
+                        "pronunciation": pronunciation,
+                    }
+                    for start, end, pronunciation in value
+                ]
         report = {
-            "format": "omnivoice_single_reference_narration_v1",
+            "format": "omnivoice_single_reference_narration_v2",
             "single_reference": True,
             "reference_switching": False,
             "seed": seed,
             "num_step": num_step,
             "candidate_count": candidates,
-            "pronunciations": {
-                plan.text[
-                    plan.controls[index].start_char : plan.controls[index].end_char
-                ]: value
-                for index, value in resolved_pronunciations.items()
-            },
+            "pronunciations": pronunciation_report,
             "baseline_frames": baseline_tokens.shape[-1],
             "final_frames": current_tokens.shape[-1],
             "baseline_transcript": _transcribe(
@@ -907,4 +1025,13 @@ class NarrationController:
             tokens=current_tokens.detach().cpu(),
             baseline_tokens=baseline_tokens.detach().cpu(),
             report=report,
+            traces=(
+                {
+                    "format": "omnivoice_narration_traces_v1",
+                    "baseline": baseline_trace[0] if baseline_trace else None,
+                    "controls": selected_traces,
+                }
+                if trace
+                else None
+            ),
         )

--- a/omnivoice/narration.py
+++ b/omnivoice/narration.py
@@ -1,0 +1,790 @@
+"""Single-reference narration controls built on local codec-token inpainting."""
+
+from __future__ import annotations
+
+import difflib
+import math
+import random
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import torch
+import torchaudio
+
+from omnivoice.controls import PausePlan, parse_pause_markers
+from omnivoice.models.omnivoice import (
+    GenerationTask,
+    OmniVoice,
+    OmniVoiceGenerationConfig,
+    VoiceClonePrompt,
+)
+
+
+@dataclass(frozen=True)
+class NarrationControl:
+    kind: str
+    start_char: int
+    end_char: int
+    value: str | float
+    source: str = "explicit"
+
+
+@dataclass(frozen=True)
+class NarrationPlan:
+    text: str
+    controls: tuple[NarrationControl, ...]
+    pause_plan: PausePlan
+    source_text: str
+
+
+@dataclass
+class NarrationResult:
+    audio: np.ndarray
+    baseline_audio: np.ndarray
+    sample_rate: int
+    plan: NarrationPlan
+    tokens: torch.Tensor
+    baseline_tokens: torch.Tensor
+    report: dict[str, Any]
+
+
+_CONTROL_TAG_RE = re.compile(
+    r"<(?P<closing>/)?(?P<name>emphasis|rate|intonation|aside)"
+    r"(?P<attrs>\s+[^<>]*?)?\s*>",
+    re.IGNORECASE,
+)
+_CONTROL_FRAGMENT_RE = re.compile(
+    r"</?(?:emphasis|rate|intonation|aside)\b", re.IGNORECASE
+)
+_ATTR_RE = re.compile(r"([a-zA-Z_][\w-]*)\s*=\s*(['\"])(.*?)\2")
+_WORD_RE = re.compile(r"[A-Za-z0-9]+(?:'[A-Za-z0-9]+)?")
+_PAUSE_RE = re.compile(r"<pause:[^<>]*>")
+
+
+def _expand_shorthand(text: str) -> str:
+    def emphasis_replacement(match: re.Match) -> str:
+        marker, content = match.group(1), match.group(2)
+        strength = "strong" if len(marker) == 3 else "moderate"
+        return (
+            f'<emphasis strength="{strength}" source="shorthand">{content}</emphasis>'
+        )
+
+    text = re.sub(r"(?<!\*)(\*{2,3})([^*\n]+?)\1(?!\*)", emphasis_replacement, text)
+    text = re.sub(
+        r"\(([^()\n]+)\)",
+        r'<aside source="shorthand">\1</aside>',
+        text,
+    )
+    text = re.sub(
+        r"—\s*([^—\n]+?)\s*—",
+        r'<emphasis strength="strong" source="dash">\1</emphasis>',
+        text,
+    )
+    return text
+
+
+def _parse_attrs(raw: str | None) -> dict[str, str]:
+    if not raw:
+        return {}
+    attrs = {}
+    consumed = []
+    for match in _ATTR_RE.finditer(raw):
+        attrs[match.group(1).lower()] = match.group(3)
+        consumed.append((match.start(), match.end()))
+    residue = list(raw)
+    for start, end in consumed:
+        residue[start:end] = " " * (end - start)
+    if "".join(residue).strip():
+        raise ValueError(f"Malformed narration-control attributes: {raw!r}")
+    return attrs
+
+
+def _control_value(kind: str, attrs: dict[str, str]) -> tuple[str | float, str]:
+    source = attrs.pop("source", "explicit")
+    if kind == "emphasis":
+        value = attrs.pop("strength", "moderate").lower()
+        if value not in {"reduced", "moderate", "strong"}:
+            raise ValueError("emphasis strength must be reduced, moderate, or strong")
+    elif kind == "rate":
+        raw = attrs.pop("value", None)
+        if raw is None:
+            raise ValueError("rate control requires value")
+        try:
+            value = float(raw)
+        except ValueError as exc:
+            raise ValueError("rate value must be numeric") from exc
+        if not math.isfinite(value) or not 0.7 <= value <= 1.4:
+            raise ValueError("rate value must be between 0.7 and 1.4")
+    elif kind == "intonation":
+        value = attrs.pop("type", "").lower()
+        if value not in {"rising", "falling"}:
+            raise ValueError("intonation type must be rising or falling")
+    else:
+        value = "parenthetical"
+    if attrs:
+        raise ValueError(f"Unsupported {kind} attribute(s): {', '.join(sorted(attrs))}")
+    return value, source
+
+
+def _remap_unchanged_span(
+    before: str, after: str, start_char: int, end_char: int
+) -> tuple[int, int]:
+    """Map a control span through pause-marker removal without guessing by text."""
+    matcher = difflib.SequenceMatcher(a=before, b=after, autojunk=False)
+    for tag, before_start, before_end, after_start, _ in matcher.get_opcodes():
+        if tag == "equal" and before_start <= start_char and end_char <= before_end:
+            return (
+                after_start + start_char - before_start,
+                after_start + end_char - before_start,
+            )
+    raise ValueError("Could not map narration control after pause removal")
+
+
+def parse_narration_controls(text: str, shorthand: bool = False) -> NarrationPlan:
+    """Parse narration markup into cleaned text and non-overlapping controls."""
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    marked_text = _expand_shorthand(text) if shorthand else text
+    controls = []
+    stack = []
+    cleaned_parts = []
+    cleaned_length = 0
+    cursor = 0
+
+    for match in _CONTROL_TAG_RE.finditer(marked_text):
+        chunk = marked_text[cursor : match.start()]
+        cleaned_parts.append(chunk)
+        cleaned_length += len(chunk)
+        name = match.group("name").lower()
+        closing = bool(match.group("closing"))
+        attrs = _parse_attrs(match.group("attrs"))
+        if closing:
+            if attrs:
+                raise ValueError(
+                    "Closing narration-control tags cannot have attributes"
+                )
+            if not stack or stack[-1][0] != name:
+                raise ValueError(f"Mismatched closing tag: {name}")
+            _, start_char, value, source = stack.pop()
+            if cleaned_length <= start_char:
+                raise ValueError(f"{name} control cannot be empty")
+            controls.append(
+                NarrationControl(name, start_char, cleaned_length, value, source)
+            )
+        else:
+            value, source = _control_value(name, attrs)
+            stack.append((name, cleaned_length, value, source))
+        cursor = match.end()
+
+    tail = marked_text[cursor:]
+    cleaned_parts.append(tail)
+    intermediate = "".join(cleaned_parts)
+    if stack:
+        raise ValueError(f"Unclosed narration-control tag: {stack[-1][0]}")
+    residue = _CONTROL_TAG_RE.sub("", marked_text)
+    if _CONTROL_FRAGMENT_RE.search(residue):
+        raise ValueError("Malformed narration-control tag")
+
+    controls.sort(key=lambda item: (item.start_char, item.end_char))
+    previous_end = -1
+    for control in controls:
+        if control.start_char < previous_end:
+            raise ValueError(
+                "Nested or overlapping narration controls are not supported"
+            )
+        if _PAUSE_RE.search(intermediate[control.start_char : control.end_char]):
+            raise ValueError("Pause markers cannot be nested inside narration controls")
+        previous_end = control.end_char
+
+    cleaned_text, pause_plan = parse_pause_markers(intermediate)
+    remapped = []
+    for control in controls:
+        start_char, end_char = _remap_unchanged_span(
+            intermediate,
+            cleaned_text,
+            control.start_char,
+            control.end_char,
+        )
+        remapped.append(
+            NarrationControl(
+                control.kind,
+                start_char,
+                end_char,
+                control.value,
+                control.source,
+            )
+        )
+
+    return NarrationPlan(
+        text=cleaned_text,
+        controls=tuple(remapped),
+        pause_plan=pause_plan,
+        source_text=text,
+    )
+
+
+def normalized_words(text: str) -> list[str]:
+    return [match.group().lower() for match in _WORD_RE.finditer(text)]
+
+
+def control_word_indices(text: str, control: NarrationControl) -> tuple[int, int]:
+    word_matches = list(_WORD_RE.finditer(text))
+    selected = [
+        index
+        for index, match in enumerate(word_matches)
+        if match.end() > control.start_char and match.start() < control.end_char
+    ]
+    if not selected:
+        raise ValueError(f"{control.kind} control does not cover any words")
+    return selected[0], selected[-1]
+
+
+def align_expected_words(expected: list[str], asr_words: list[dict]) -> dict[int, int]:
+    actual = [word["normalized"] for word in asr_words]
+    matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
+    mapping = {}
+    for block in matcher.get_matching_blocks():
+        for delta in range(block.size):
+            mapping[block.a + delta] = block.b + delta
+    return mapping
+
+
+def build_inpaint_template(
+    tokens: torch.Tensor,
+    frame_start: int,
+    frame_end: int,
+    new_core_frames: int,
+    mask_id: int,
+    transition_frames: int = 5,
+) -> tuple[torch.Tensor, tuple[int, int], tuple[int, int]]:
+    """Replace one token span with masks while preserving every outside token."""
+    total_frames = tokens.shape[-1]
+    if not 0 <= frame_start < frame_end <= total_frames:
+        raise ValueError("Invalid controlled frame span")
+    if new_core_frames < 1:
+        raise ValueError("Controlled span must retain at least one frame")
+    window_start = max(0, frame_start - transition_frames)
+    window_end = min(total_frames, frame_end + transition_frames)
+    left_transition = frame_start - window_start
+    right_transition = window_end - frame_end
+    new_window_frames = left_transition + new_core_frames + right_transition
+    masks = torch.full(
+        (tokens.shape[0], new_window_frames),
+        mask_id,
+        dtype=tokens.dtype,
+        device=tokens.device,
+    )
+    template = torch.cat(
+        (tokens[:, :window_start], masks, tokens[:, window_end:]), dim=-1
+    )
+    new_core_start = window_start + left_transition
+    return (
+        template,
+        (window_start, window_end),
+        (
+            new_core_start,
+            new_core_start + new_core_frames,
+        ),
+    )
+
+
+def _conditioned_text(text: str, control: NarrationControl) -> str:
+    before = text[: control.start_char]
+    surface = text[control.start_char : control.end_char]
+    after = text[control.end_char :]
+    if control.kind == "emphasis":
+        if control.value == "reduced":
+            replacement = f"({surface})"
+        elif control.value == "strong":
+            replacement = f"—{surface.upper()}—"
+        else:
+            replacement = f"—{surface}—"
+    elif control.kind == "aside":
+        replacement = f"({surface})"
+    elif control.kind == "intonation":
+        replacement = surface.rstrip(".!?") + (
+            "?" if control.value == "rising" else "."
+        )
+    else:
+        replacement = surface
+    return before + replacement + after
+
+
+def _core_frame_target(control: NarrationControl, original_frames: int) -> int:
+    if control.kind == "rate":
+        factor = float(control.value)
+    elif control.kind == "aside":
+        factor = 1.12
+    elif control.kind == "emphasis":
+        factor = {"reduced": 1.1, "moderate": 0.87, "strong": 0.74}[str(control.value)]
+    else:
+        factor = 1.0
+    return max(1, int(math.floor(original_frames / factor + 0.5)))
+
+
+def _set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _decode_tokens(model: OmniVoice, tokens: torch.Tensor) -> np.ndarray:
+    return (
+        model.audio_tokenizer.decode(
+            tokens.to(model.audio_tokenizer.device).unsqueeze(0)
+        )
+        .audio_values[0]
+        .detach()
+        .cpu()
+        .numpy()
+        .squeeze(0)
+    )
+
+
+def _transcribe(aligner, audio: np.ndarray, sample_rate: int = 24000) -> dict[str, Any]:
+    waveform = torch.from_numpy(audio.astype(np.float32, copy=False))
+    if sample_rate != 16000:
+        waveform = torchaudio.functional.resample(
+            waveform, orig_freq=sample_rate, new_freq=16000
+        )
+    segments, info = aligner.transcribe(
+        waveform.numpy(),
+        language="en",
+        beam_size=5,
+        word_timestamps=True,
+    )
+    words = []
+    text_parts = []
+    for segment in segments:
+        text_parts.append(segment.text.strip())
+        for word in segment.words or []:
+            normalized = normalized_words(word.word)
+            if not normalized:
+                continue
+            words.append(
+                {
+                    "word": word.word.strip(),
+                    "normalized": normalized[0],
+                    "start": float(word.start),
+                    "end": float(word.end),
+                    "probability": float(word.probability),
+                }
+            )
+    return {
+        "text": " ".join(part for part in text_parts if part).strip(),
+        "words": words,
+        "normalized_words": [word["normalized"] for word in words],
+        "language": info.language,
+        "language_probability": float(info.language_probability),
+    }
+
+
+def _rms_db(audio: np.ndarray) -> float:
+    if audio.size == 0:
+        return -120.0
+    rms = float(np.sqrt(np.mean(np.square(audio, dtype=np.float64))))
+    return 20.0 * math.log10(max(rms, 1e-6))
+
+
+def _pitch_slope(audio: np.ndarray, sample_rate: int) -> float:
+    if audio.size < int(sample_rate * 0.12):
+        return 0.0
+    waveform = torch.from_numpy(audio.astype(np.float32, copy=False)).unsqueeze(0)
+    try:
+        pitch = torchaudio.functional.detect_pitch_frequency(
+            waveform,
+            sample_rate,
+            frame_time=0.02,
+            win_length=5,
+            freq_low=70,
+            freq_high=350,
+        ).squeeze(0)
+    except RuntimeError:
+        return 0.0
+    pitch = pitch[torch.isfinite(pitch) & (pitch > 0)]
+    if pitch.numel() < 4:
+        return 0.0
+    split = max(1, pitch.numel() // 3)
+    first = float(pitch[:split].median())
+    last = float(pitch[-split:].median())
+    return math.log2(max(last, 1.0) / max(first, 1.0)) * 12.0
+
+
+def _aligned_control_audio(
+    text: str,
+    control: NarrationControl,
+    transcript: dict[str, Any],
+    audio: np.ndarray,
+    sample_rate: int,
+) -> Optional[dict[str, Any]]:
+    expected = normalized_words(text)
+    mapping = align_expected_words(expected, transcript["words"])
+    first_word, last_word = control_word_indices(text, control)
+    if control.kind == "intonation":
+        # Sentence-ending pitch needs enough voiced context to measure and repaint.
+        first_word = max(first_word, last_word - 2)
+    required = range(first_word, last_word + 1)
+    if any(index not in mapping for index in required):
+        return None
+    first = transcript["words"][mapping[first_word]]
+    last = transcript["words"][mapping[last_word]]
+    start_sample = max(0, int(first["start"] * sample_rate))
+    end_sample = min(audio.size, int(last["end"] * sample_rate))
+    segment = audio[start_sample:end_sample]
+    return {
+        "first_word_index": first_word,
+        "last_word_index": last_word,
+        "start_seconds": first["start"],
+        "end_seconds": last["end"],
+        "duration_seconds": max(0.0, last["end"] - first["start"]),
+        "rms_db": _rms_db(segment),
+        "pitch_slope_semitones": _pitch_slope(segment, sample_rate),
+        "word_match_ratio": len(mapping) / max(1, len(expected)),
+    }
+
+
+def _score_candidate(
+    text: str,
+    control: NarrationControl,
+    transcript: dict[str, Any],
+    audio: np.ndarray,
+    sample_rate: int,
+    target_duration: float,
+) -> tuple[float, dict[str, Any]]:
+    metrics = _aligned_control_audio(text, control, transcript, audio, sample_rate)
+    if metrics is None:
+        return -1e9, {"alignment_failed": True}
+    word_match = metrics["word_match_ratio"]
+    duration_error = abs(metrics["duration_seconds"] - target_duration)
+    score = word_match * 100.0 - duration_error * 12.0
+    whole_rms = _rms_db(audio)
+    prominence = metrics["rms_db"] - whole_rms
+    if control.kind == "emphasis":
+        weight = {"reduced": -2.0, "moderate": 1.0, "strong": 2.0}[str(control.value)]
+        score += prominence * weight
+    elif control.kind == "aside":
+        score -= prominence * 1.5
+    elif control.kind == "intonation":
+        direction = 1.0 if control.value == "rising" else -1.0
+        score += metrics["pitch_slope_semitones"] * direction * 3.0
+    metrics.update(
+        {
+            "alignment_failed": False,
+            "whole_rms_db": whole_rms,
+            "prominence_db": prominence,
+            "target_duration_seconds": target_duration,
+            "duration_error_seconds": duration_error,
+        }
+    )
+    return score, metrics
+
+
+def _shift_fixed_spans(
+    spans: tuple[tuple[int, int], ...],
+    old_window: tuple[int, int],
+    new_window_length: int,
+) -> tuple[tuple[int, int], ...]:
+    old_start, old_end = old_window
+    delta = new_window_length - (old_end - old_start)
+    shifted = []
+    for start, end in spans:
+        if end <= old_start:
+            shifted.append((start, end))
+        elif start >= old_end:
+            shifted.append((start + delta, end + delta))
+        else:
+            raise ValueError(
+                "Narration control is too close to a fixed pause-token span"
+            )
+    return tuple(shifted)
+
+
+class NarrationController:
+    """Apply local narration controls while reusing one voice-clone prompt."""
+
+    def __init__(
+        self,
+        model: OmniVoice,
+        aligner: Any = None,
+        aligner_path: str | Path = "Systran/faster-whisper-small.en",
+        aligner_device: str = "cpu",
+        aligner_compute_type: str = "int8",
+        local_files_only: bool = False,
+    ):
+        self.model = model
+        self._aligner = aligner
+        self.aligner_path = str(aligner_path)
+        self.aligner_device = aligner_device
+        self.aligner_compute_type = aligner_compute_type
+        self.local_files_only = local_files_only
+
+    @property
+    def aligner(self):
+        if self._aligner is None:
+            try:
+                from faster_whisper import WhisperModel
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Narration controls require faster-whisper for word alignment"
+                ) from exc
+            self._aligner = WhisperModel(
+                self.aligner_path,
+                device=self.aligner_device,
+                compute_type=self.aligner_compute_type,
+                local_files_only=self.local_files_only,
+            )
+        return self._aligner
+
+    def _resolve_prompt(
+        self,
+        voice_clone_prompt: Optional[VoiceClonePrompt],
+        ref_audio,
+        ref_text: Optional[str],
+        preprocess_prompt: bool,
+    ) -> VoiceClonePrompt:
+        if voice_clone_prompt is not None:
+            if ref_audio is not None or ref_text is not None:
+                raise ValueError(
+                    "Use voice_clone_prompt or ref_audio/ref_text, not both"
+                )
+            return voice_clone_prompt
+        if ref_audio is None:
+            raise ValueError("Narration controls require one clone reference")
+        return self.model.create_voice_clone_prompt(
+            ref_audio,
+            ref_text=ref_text,
+            preprocess_prompt=preprocess_prompt,
+        )
+
+    def _make_task(
+        self,
+        text: str,
+        prompt: VoiceClonePrompt,
+        language: Optional[str],
+        config: OmniVoiceGenerationConfig,
+        target_template: torch.Tensor,
+        pause_spans: tuple[tuple[int, int], ...],
+    ) -> GenerationTask:
+        task = self.model._preprocess_all(
+            text=text,
+            language=language,
+            voice_clone_prompt=prompt,
+            preprocess_prompt=config.preprocess_prompt,
+            speed=1.0,
+            duration=None,
+        )
+        task.target_lens = [target_template.shape[-1]]
+        task.target_templates = [target_template]
+        task.pause_spans = [pause_spans]
+        task.controlled = [True]
+        return task
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        text: str,
+        *,
+        ref_audio=None,
+        ref_text: Optional[str] = None,
+        voice_clone_prompt: Optional[VoiceClonePrompt] = None,
+        language: Optional[str] = "English",
+        shorthand: bool = False,
+        num_step: int = 32,
+        candidates: int = 3,
+        seed: int = 1234,
+        preprocess_prompt: bool = True,
+    ) -> NarrationResult:
+        if candidates < 1:
+            raise ValueError("candidates must be at least 1")
+        plan = parse_narration_controls(text, shorthand=shorthand)
+        prompt = self._resolve_prompt(
+            voice_clone_prompt, ref_audio, ref_text, preprocess_prompt
+        )
+        config = OmniVoiceGenerationConfig(
+            num_step=num_step, preprocess_prompt=preprocess_prompt
+        )
+
+        _set_seed(seed)
+        baseline_task = self.model._preprocess_all(
+            text=plan.text,
+            language=language,
+            voice_clone_prompt=prompt,
+            preprocess_prompt=preprocess_prompt,
+            speed=1.0,
+            duration=None,
+            pause_plan=plan.pause_plan if plan.pause_plan.pauses else None,
+        )
+        short_idx, long_idx = baseline_task.get_indices(
+            config, self.model.audio_tokenizer.config.frame_rate
+        )
+        if long_idx or short_idx != [0]:
+            raise ValueError("Narration controls support one short-form item only")
+        baseline_tokens = self.model._generate_iterative(baseline_task, config)[0]
+        baseline_raw = _decode_tokens(self.model, baseline_tokens)
+        baseline_audio = self.model._decode_and_post_process(
+            baseline_tokens,
+            baseline_task.ref_rms[0],
+            config,
+            preserve_internal_silence=bool(plan.pause_plan.pauses),
+        )
+
+        current_tokens = baseline_tokens
+        current_raw = baseline_raw
+        pause_spans = baseline_task.pause_spans[0]
+        expected_words = normalized_words(plan.text)
+        control_reports = []
+        frame_rate = self.model.audio_tokenizer.config.frame_rate
+
+        for control_index, control in enumerate(plan.controls):
+            transcript = _transcribe(
+                self.aligner, current_raw, self.model.sampling_rate
+            )
+            mapping = align_expected_words(expected_words, transcript["words"])
+            first_word, last_word = control_word_indices(plan.text, control)
+            if any(index not in mapping for index in range(first_word, last_word + 1)):
+                raise RuntimeError(f"Could not align words for {control.kind} control")
+            first = transcript["words"][mapping[first_word]]
+            last = transcript["words"][mapping[last_word]]
+            source_metrics = _aligned_control_audio(
+                plan.text,
+                control,
+                transcript,
+                current_raw,
+                self.model.sampling_rate,
+            )
+            assert source_metrics is not None
+            source_metrics["whole_rms_db"] = _rms_db(current_raw)
+            source_metrics["prominence_db"] = (
+                source_metrics["rms_db"] - source_metrics["whole_rms_db"]
+            )
+            frame_start = max(0, int(math.floor(first["start"] * frame_rate)))
+            frame_end = min(
+                current_tokens.shape[-1],
+                max(frame_start + 1, int(math.ceil(last["end"] * frame_rate))),
+            )
+            original_frames = frame_end - frame_start
+            new_core_frames = _core_frame_target(control, original_frames)
+            template, old_window, new_core_span = build_inpaint_template(
+                current_tokens,
+                frame_start,
+                frame_end,
+                new_core_frames,
+                self.model.config.audio_mask_id,
+            )
+            new_window_length = (
+                old_window[1]
+                - old_window[0]
+                + template.shape[-1]
+                - current_tokens.shape[-1]
+            )
+            pause_spans = _shift_fixed_spans(pause_spans, old_window, new_window_length)
+            conditioned_text = _conditioned_text(plan.text, control)
+            target_duration = (
+                source_metrics["duration_seconds"]
+                if control.kind == "intonation"
+                else new_core_frames / frame_rate
+            )
+            candidate_reports = []
+            best = None
+
+            for candidate_index in range(candidates):
+                candidate_seed = seed + (control_index + 1) * 100 + candidate_index
+                _set_seed(candidate_seed)
+                task = self._make_task(
+                    conditioned_text,
+                    prompt,
+                    language,
+                    config,
+                    template,
+                    pause_spans,
+                )
+                candidate_tokens = self.model._generate_iterative(task, config)[0]
+                fixed = template != self.model.config.audio_mask_id
+                fixed_tokens_unchanged = bool(
+                    torch.equal(candidate_tokens[fixed], template[fixed])
+                )
+                candidate_raw = _decode_tokens(self.model, candidate_tokens)
+                candidate_transcript = _transcribe(
+                    self.aligner, candidate_raw, self.model.sampling_rate
+                )
+                score, metrics = _score_candidate(
+                    plan.text,
+                    control,
+                    candidate_transcript,
+                    candidate_raw,
+                    self.model.sampling_rate,
+                    target_duration,
+                )
+                candidate_report = {
+                    "candidate": candidate_index,
+                    "seed": candidate_seed,
+                    "score": score,
+                    "transcript": candidate_transcript["text"],
+                    "normalized_words": candidate_transcript["normalized_words"],
+                    "fixed_tokens_unchanged": fixed_tokens_unchanged,
+                    "fixed_token_fraction": float(fixed.float().mean().item()),
+                    "metrics": metrics,
+                }
+                candidate_reports.append(candidate_report)
+                if best is None or score > best[0]:
+                    best = (score, candidate_tokens, candidate_raw, candidate_index)
+
+            assert best is not None
+            current_tokens = best[1]
+            current_raw = best[2]
+            control_reports.append(
+                {
+                    "control": asdict(control),
+                    "source_frame_span": [frame_start, frame_end],
+                    "source_frames": original_frames,
+                    "target_frames": new_core_frames,
+                    "source_metrics": source_metrics,
+                    "inpaint_window": list(old_window),
+                    "new_core_span": list(new_core_span),
+                    "selected_candidate": best[3],
+                    "candidates": candidate_reports,
+                }
+            )
+
+        final_audio = self.model._decode_and_post_process(
+            current_tokens,
+            baseline_task.ref_rms[0],
+            config,
+            preserve_internal_silence=bool(plan.pause_plan.pauses),
+        )
+        final_transcript = _transcribe(
+            self.aligner, current_raw, self.model.sampling_rate
+        )
+        report = {
+            "format": "omnivoice_single_reference_narration_v1",
+            "single_reference": True,
+            "reference_switching": False,
+            "seed": seed,
+            "num_step": num_step,
+            "candidate_count": candidates,
+            "baseline_frames": baseline_tokens.shape[-1],
+            "final_frames": current_tokens.shape[-1],
+            "baseline_transcript": _transcribe(
+                self.aligner, baseline_raw, self.model.sampling_rate
+            )["text"],
+            "final_transcript": final_transcript["text"],
+            "final_normalized_words": final_transcript["normalized_words"],
+            "expected_normalized_words": expected_words,
+            "word_sequence_matches": final_transcript["normalized_words"]
+            == expected_words,
+            "controls": control_reports,
+        }
+        return NarrationResult(
+            audio=final_audio,
+            baseline_audio=baseline_audio,
+            sample_rate=self.model.sampling_rate,
+            plan=plan,
+            tokens=current_tokens.detach().cpu(),
+            baseline_tokens=baseline_tokens.detach().cpu(),
+            report=report,
+        )

--- a/omnivoice/narration.py
+++ b/omnivoice/narration.py
@@ -62,6 +62,49 @@ _CONTROL_FRAGMENT_RE = re.compile(
 _ATTR_RE = re.compile(r"([a-zA-Z_][\w-]*)\s*=\s*(['\"])(.*?)\2")
 _WORD_RE = re.compile(r"[A-Za-z0-9]+(?:'[A-Za-z0-9]+)?")
 _PAUSE_RE = re.compile(r"<pause:[^<>]*>")
+_CMU_VOWELS = {
+    "AA",
+    "AE",
+    "AH",
+    "AO",
+    "AW",
+    "AY",
+    "EH",
+    "ER",
+    "EY",
+    "IH",
+    "IY",
+    "OW",
+    "OY",
+    "UH",
+    "UW",
+}
+_CMU_CONSONANTS = {
+    "B",
+    "CH",
+    "D",
+    "DH",
+    "F",
+    "G",
+    "HH",
+    "JH",
+    "K",
+    "L",
+    "M",
+    "N",
+    "NG",
+    "P",
+    "R",
+    "S",
+    "SH",
+    "T",
+    "TH",
+    "V",
+    "W",
+    "Y",
+    "Z",
+    "ZH",
+}
 
 
 def _expand_shorthand(text: str) -> str:
@@ -141,6 +184,63 @@ def _remap_unchanged_span(
                 after_start + end_char - before_start,
             )
     raise ValueError("Could not map narration control after pause removal")
+
+
+def _normalize_cmu_pronunciation(value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError("CMU pronunciation values must be strings")
+    raw = value.strip()
+    if raw.startswith("[") or raw.endswith("]"):
+        if not (raw.startswith("[") and raw.endswith("]")):
+            raise ValueError("CMU pronunciation brackets must be balanced")
+        raw = raw[1:-1].strip()
+    tokens = raw.upper().split()
+    if not tokens:
+        raise ValueError("CMU pronunciation cannot be empty")
+    for token in tokens:
+        base = token.rstrip("012")
+        stress = token[len(base) :]
+        if base in _CMU_VOWELS:
+            if stress not in {"0", "1", "2"}:
+                raise ValueError(f"CMU vowel requires stress 0, 1, or 2: {token}")
+        elif base in _CMU_CONSONANTS:
+            if stress:
+                raise ValueError(f"CMU consonant cannot have stress: {token}")
+        else:
+            raise ValueError(f"Unknown CMU phoneme: {token}")
+    return f"[{' '.join(tokens)}]"
+
+
+def _resolve_pronunciations(
+    plan: NarrationPlan, pronunciations: Optional[dict[str, str]]
+) -> dict[int, str]:
+    if pronunciations is None:
+        return {}
+    if not isinstance(pronunciations, dict):
+        raise TypeError("pronunciations must be a dictionary")
+
+    surfaces: dict[str, list[int]] = {}
+    for index, control in enumerate(plan.controls):
+        surface = plan.text[control.start_char : control.end_char].strip().casefold()
+        surfaces.setdefault(surface, []).append(index)
+
+    resolved = {}
+    seen_keys = set()
+    for raw_key, raw_value in pronunciations.items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            raise TypeError("pronunciation keys must be nonempty strings")
+        key = raw_key.strip().casefold()
+        if key in seen_keys:
+            raise ValueError(f"Duplicate pronunciation key: {raw_key!r}")
+        seen_keys.add(key)
+        if key not in surfaces:
+            raise ValueError(
+                f"Pronunciation key does not match a controlled span: {raw_key!r}"
+            )
+        pronunciation = _normalize_cmu_pronunciation(raw_value)
+        for control_index in surfaces[key]:
+            resolved[control_index] = pronunciation
+    return resolved
 
 
 def parse_narration_controls(text: str, shorthand: bool = False) -> NarrationPlan:
@@ -291,25 +391,30 @@ def build_inpaint_template(
     )
 
 
-def _conditioned_text(text: str, control: NarrationControl) -> str:
+def _conditioned_text(
+    text: str,
+    control: NarrationControl,
+    pronunciation: Optional[str] = None,
+) -> str:
     before = text[: control.start_char]
     surface = text[control.start_char : control.end_char]
     after = text[control.end_char :]
+    spoken = pronunciation or surface
     if control.kind == "emphasis":
         if control.value == "reduced":
-            replacement = f"({surface})"
+            replacement = f"({spoken})"
         elif control.value == "strong":
-            replacement = f"—{surface.upper()}—"
+            replacement = f"—{spoken if pronunciation else surface.upper()}—"
         else:
-            replacement = f"—{surface}—"
+            replacement = f"—{spoken}—"
     elif control.kind == "aside":
-        replacement = f"({surface})"
+        replacement = f"({spoken})"
     elif control.kind == "intonation":
-        replacement = surface.rstrip(".!?") + (
+        replacement = (spoken if pronunciation else surface.rstrip(".!?")) + (
             "?" if control.value == "rising" else "."
         )
     else:
-        replacement = surface
+        replacement = spoken
     return before + replacement + after
 
 
@@ -598,10 +703,12 @@ class NarrationController:
         candidates: int = 3,
         seed: int = 1234,
         preprocess_prompt: bool = True,
+        pronunciations: Optional[dict[str, str]] = None,
     ) -> NarrationResult:
         if candidates < 1:
             raise ValueError("candidates must be at least 1")
         plan = parse_narration_controls(text, shorthand=shorthand)
+        resolved_pronunciations = _resolve_pronunciations(plan, pronunciations)
         prompt = self._resolve_prompt(
             voice_clone_prompt, ref_audio, ref_text, preprocess_prompt
         )
@@ -683,7 +790,12 @@ class NarrationController:
                 - current_tokens.shape[-1]
             )
             pause_spans = _shift_fixed_spans(pause_spans, old_window, new_window_length)
-            conditioned_text = _conditioned_text(plan.text, control)
+            pronunciation = resolved_pronunciations.get(control_index)
+            conditioned_text = _conditioned_text(
+                plan.text,
+                control,
+                pronunciation=pronunciation,
+            )
             target_duration = (
                 source_metrics["duration_seconds"]
                 if control.kind == "intonation"
@@ -743,6 +855,8 @@ class NarrationController:
                     "source_frame_span": [frame_start, frame_end],
                     "source_frames": original_frames,
                     "target_frames": new_core_frames,
+                    "pronunciation": pronunciation,
+                    "conditioned_text": conditioned_text,
                     "source_metrics": source_metrics,
                     "inpaint_window": list(old_window),
                     "new_core_span": list(new_core_span),
@@ -767,6 +881,12 @@ class NarrationController:
             "seed": seed,
             "num_step": num_step,
             "candidate_count": candidates,
+            "pronunciations": {
+                plan.text[
+                    plan.controls[index].start_char : plan.controls[index].end_char
+                ]: value
+                for index, value in resolved_pronunciations.items()
+            },
             "baseline_frames": baseline_tokens.shape[-1],
             "final_frames": current_tokens.shape[-1],
             "baseline_transcript": _transcribe(

--- a/omnivoice/narration.py
+++ b/omnivoice/narration.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 import torchaudio
 
-from omnivoice.controls import PausePlan, parse_pause_markers
+from omnivoice.controls import PausePlan, PauseSpec, parse_pause_markers
 from omnivoice.models.omnivoice import (
     GenerationTask,
     OmniVoice,
@@ -264,8 +264,8 @@ def _resolve_pronunciations(
             raise ValueError(f"Duplicate pronunciation key: {raw_key!r}")
         seen_keys.add(key)
         pronunciation = _normalize_cmu_pronunciation(raw_value)
-        matched = False
         pattern = re.compile(r"(?<![A-Za-z0-9'])" + re.escape(key) + r"(?![A-Za-z0-9'])")
+        matched = bool(pattern.search(plan.text.casefold()))
         for control_index, control in enumerate(plan.controls):
             surface = plan.text[control.start_char : control.end_char]
             for match in pattern.finditer(surface.casefold()):
@@ -274,7 +274,6 @@ def _resolve_pronunciations(
                 if any(start < old_end and old_start < end for old_start, old_end, _ in parts):
                     continue
                 parts.append((start, end, pronunciation))
-                matched = True
         if not matched:
             raise ValueError(
                 f"Pronunciation key does not match a controlled span: {raw_key!r}"
@@ -290,6 +289,73 @@ def _resolve_pronunciations(
         else:
             resolved[control_index] = tuple(parts)
     return resolved
+
+
+def _pronunciation_replacements(
+    text: str, pronunciations: Optional[dict[str, str]]
+) -> list[tuple[int, int, str]]:
+    if pronunciations is None:
+        return []
+    if not isinstance(pronunciations, dict):
+        raise TypeError("pronunciations must be a dictionary")
+    replacements = []
+    occupied: list[tuple[int, int]] = []
+    ordered = sorted(
+        pronunciations.items(), key=lambda item: len(str(item[0]).strip()), reverse=True
+    )
+    for raw_key, raw_value in ordered:
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            raise TypeError("pronunciation keys must be nonempty strings")
+        key = raw_key.strip()
+        pronunciation = _normalize_cmu_pronunciation(raw_value)
+        pattern = re.compile(
+            r"(?<![A-Za-z0-9'])" + re.escape(key) + r"(?![A-Za-z0-9'])",
+            re.IGNORECASE,
+        )
+        for match in pattern.finditer(text):
+            start, end = match.span()
+            if any(start < old_end and old_start < end for old_start, old_end in occupied):
+                continue
+            occupied.append((start, end))
+            replacements.append((start, end, pronunciation))
+    replacements.sort(key=lambda item: item[0])
+    return replacements
+
+
+def _apply_pronunciations(
+    text: str, pronunciations: Optional[dict[str, str]]
+) -> str:
+    replacements = _pronunciation_replacements(text, pronunciations)
+    if not replacements:
+        return text
+    parts = []
+    cursor = 0
+    for start, end, pronunciation in replacements:
+        parts.extend((text[cursor:start], pronunciation))
+        cursor = end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _apply_pronunciations_to_pause_plan(
+    text: str,
+    pause_plan: PausePlan,
+    pronunciations: Optional[dict[str, str]],
+) -> tuple[str, PausePlan]:
+    replacements = _pronunciation_replacements(text, pronunciations)
+    if not replacements:
+        return text, pause_plan
+    conditioned = _apply_pronunciations(text, pronunciations)
+    remapped = []
+    for pause in pause_plan.pauses:
+        delta = 0
+        for start, end, pronunciation in replacements:
+            if pause.after_char >= end:
+                delta += len(pronunciation) - (end - start)
+            elif start < pause.after_char < end:
+                raise ValueError("Pause cannot split a pronunciation-controlled word")
+        remapped.append(PauseSpec(pause.after_char + delta, pause.seconds))
+    return conditioned, PausePlan(tuple(remapped))
 
 
 def parse_narration_controls(text: str, shorthand: bool = False) -> NarrationPlan:
@@ -809,14 +875,17 @@ class NarrationController:
         )
 
         _set_seed(seed)
+        baseline_text, baseline_pause_plan = _apply_pronunciations_to_pause_plan(
+            plan.text, plan.pause_plan, pronunciations
+        )
         baseline_task = self.model._preprocess_all(
-            text=plan.text,
+            text=baseline_text,
             language=language,
             voice_clone_prompt=prompt,
             preprocess_prompt=preprocess_prompt,
             speed=1.0,
             duration=None,
-            pause_plan=plan.pause_plan if plan.pause_plan.pauses else None,
+            pause_plan=baseline_pause_plan if baseline_pause_plan.pauses else None,
         )
         short_idx, long_idx = baseline_task.get_indices(
             config, self.model.audio_tokenizer.config.frame_rate
@@ -891,6 +960,9 @@ class NarrationController:
                 plan.text,
                 control,
                 pronunciation=pronunciation,
+            )
+            conditioned_text = _apply_pronunciations(
+                conditioned_text, pronunciations
             )
             target_duration = (
                 source_metrics["duration_seconds"]
@@ -982,7 +1054,10 @@ class NarrationController:
         final_transcript = _transcribe(
             self.aligner, current_raw, self.model.sampling_rate
         )
-        pronunciation_report = {}
+        pronunciation_report = {
+            str(surface): _normalize_cmu_pronunciation(value)
+            for surface, value in (pronunciations or {}).items()
+        }
         for index, value in resolved_pronunciations.items():
             surface = plan.text[
                 plan.controls[index].start_char : plan.controls[index].end_char

--- a/omnivoice/narration.py
+++ b/omnivoice/narration.py
@@ -473,7 +473,7 @@ def build_inpaint_template(
     frame_end: int,
     new_core_frames: int,
     mask_id: int,
-    transition_frames: int = 5,
+    transition_frames: int | tuple[int, int] = 5,
 ) -> tuple[torch.Tensor, tuple[int, int], tuple[int, int]]:
     """Replace one token span with masks while preserving every outside token."""
     total_frames = tokens.shape[-1]
@@ -481,8 +481,14 @@ def build_inpaint_template(
         raise ValueError("Invalid controlled frame span")
     if new_core_frames < 1:
         raise ValueError("Controlled span must retain at least one frame")
-    window_start = max(0, frame_start - transition_frames)
-    window_end = min(total_frames, frame_end + transition_frames)
+    if isinstance(transition_frames, tuple):
+        left_transition, right_transition = transition_frames
+    else:
+        left_transition = right_transition = transition_frames
+    if left_transition < 0 or right_transition < 0:
+        raise ValueError("Transition frames cannot be negative")
+    window_start = max(0, frame_start - left_transition)
+    window_end = min(total_frames, frame_end + right_transition)
     left_transition = frame_start - window_start
     right_transition = window_end - frame_end
     new_window_frames = left_transition + new_core_frames + right_transition
@@ -504,6 +510,23 @@ def build_inpaint_template(
             new_core_start + new_core_frames,
         ),
     )
+
+
+def _transition_frames_around_fixed_spans(
+    frame_start: int,
+    frame_end: int,
+    fixed_spans: tuple[tuple[int, int], ...],
+    wanted: int = 5,
+) -> tuple[int, int]:
+    left = right = wanted
+    for start, end in fixed_spans:
+        if end <= frame_start:
+            left = min(left, frame_start - end)
+        elif start >= frame_end:
+            right = min(right, start - frame_end)
+        else:
+            raise ValueError("Narration control overlaps a fixed pause-token span")
+    return left, right
 
 
 def _conditioned_text(
@@ -941,12 +964,16 @@ class NarrationController:
             )
             original_frames = frame_end - frame_start
             new_core_frames = _core_frame_target(control, original_frames)
+            transition_frames = _transition_frames_around_fixed_spans(
+                frame_start, frame_end, pause_spans
+            )
             template, old_window, new_core_span = build_inpaint_template(
                 current_tokens,
                 frame_start,
                 frame_end,
                 new_core_frames,
                 self.model.config.audio_mask_id,
+                transition_frames=transition_frames,
             )
             new_window_length = (
                 old_window[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ dependencies = [
 
 [project.optional-dependencies]
 
+narration = [
+    "faster-whisper>=1.2.1",
+]
+
 eval = [
     "jiwer==3.1.0",       # WER
     "s3prl",               # Speech representation (HuBERT etc.)

--- a/reports/cmu_pronunciation_results.json
+++ b/reports/cmu_pronunciation_results.json
@@ -1,0 +1,186 @@
+{
+  "format": "omnivoice_cmu_pronunciation_smoke_v1",
+  "experiment_revision": "7561686e3405ff504778d293bdf42d47c925111b",
+  "reference_basename": "explaining_sub_11s_24k.wav",
+  "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+  "reference_switching": false,
+  "num_step": 128,
+  "candidates": 3,
+  "dictionary_source": "CMUdict master and cmudict.0.7a",
+  "listening_status": "manual review pending",
+  "controlled_cases": [
+    {
+      "case_id": "unexpected",
+      "variants": [
+        {
+          "id": "legacy",
+          "audio": "legacy.wav",
+          "audio_sha256": "4592bd7f94ea3e9a43680e2987c7b4849b5a07a82c24f78ca6317897c9dfd9eb",
+          "baseline_transcript": "This was unexpected.",
+          "final_transcript": "This was unexpected",
+          "word_sequence_matches": true,
+          "metrics": {
+            "source_frames": 13,
+            "target_frames": 18,
+            "pronunciation": null,
+            "conditioned_text": "This was \u2014UNEXPECTED\u2014.",
+            "selected_candidate": 0,
+            "fixed_tokens_unchanged": true,
+            "source_duration_seconds": 0.52,
+            "selected_duration_seconds": 0.58,
+            "prominence_change_db": -2.932924177321514,
+            "pitch_slope_change_semitones": 1.4405772587297578
+          }
+        },
+        {
+          "id": "cmu",
+          "audio": "cmu.wav",
+          "audio_sha256": "080cd065c91df9ca8432e586dd41b1f791646cca28525836d6efce541c58dfed",
+          "baseline_transcript": "This was unexpected.",
+          "final_transcript": "This was unexpected.",
+          "word_sequence_matches": true,
+          "metrics": {
+            "source_frames": 13,
+            "target_frames": 18,
+            "pronunciation": "[AH2 N IH0 K S P EH1 K T IH0 D]",
+            "conditioned_text": "This was \u2014[AH2 N IH0 K S P EH1 K T IH0 D]\u2014.",
+            "selected_candidate": 1,
+            "fixed_tokens_unchanged": true,
+            "source_duration_seconds": 0.52,
+            "selected_duration_seconds": 0.62,
+            "prominence_change_db": -5.401168964205169,
+            "pitch_slope_change_semitones": 5.76247759274856
+          }
+        }
+      ],
+      "baseline": "00_baseline.wav",
+      "baseline_sha256": "0265eb3ad232a561a134008f5c1cfa803ec87f2055b8e41d2c9a838d8b1b4ab8"
+    },
+    {
+      "case_id": "nobody",
+      "variants": [
+        {
+          "id": "legacy",
+          "audio": "legacy.wav",
+          "audio_sha256": "6b95f20ed28c73c899789dbc0f080e75204b071e0d89c0ec6a76b5f7ec51aaf6",
+          "baseline_transcript": "This was important, but nobody understood why.",
+          "final_transcript": "This was important, but nobody understood why.",
+          "word_sequence_matches": true,
+          "metrics": {
+            "source_frames": 7,
+            "target_frames": 9,
+            "pronunciation": null,
+            "conditioned_text": "This was important, but \u2014NOBODY\u2014 understood why.",
+            "selected_candidate": 2,
+            "fixed_tokens_unchanged": true,
+            "source_duration_seconds": 0.26,
+            "selected_duration_seconds": 0.32000000000000006,
+            "prominence_change_db": -0.24831280338557526,
+            "pitch_slope_change_semitones": -0.4815837336459712
+          }
+        },
+        {
+          "id": "cmu_primary",
+          "audio": "cmu_primary.wav",
+          "audio_sha256": "09a34023ac65040f700d879fa9103bf065dbf67756f2f0cc6c9a566580156be7",
+          "baseline_transcript": "This was important, but nobody understood why.",
+          "final_transcript": "This was important, but nobody understood why.",
+          "word_sequence_matches": true,
+          "metrics": {
+            "source_frames": 7,
+            "target_frames": 9,
+            "pronunciation": "[N OW1 B AA2 D IY2]",
+            "conditioned_text": "This was important, but \u2014[N OW1 B AA2 D IY2]\u2014 understood why.",
+            "selected_candidate": 0,
+            "fixed_tokens_unchanged": true,
+            "source_duration_seconds": 0.26,
+            "selected_duration_seconds": 0.30000000000000004,
+            "prominence_change_db": -1.2333271384651177,
+            "pitch_slope_change_semitones": -0.6486819787351101
+          }
+        },
+        {
+          "id": "cmu_reduced",
+          "audio": "cmu_reduced.wav",
+          "audio_sha256": "e636b40ab8f82d206c7659b4f8210bbcd8d3f309d506201f09493c9b76568f4d",
+          "baseline_transcript": "This was important, but nobody understood why.",
+          "final_transcript": "This was important, but nobody understood why.",
+          "word_sequence_matches": true,
+          "metrics": {
+            "source_frames": 7,
+            "target_frames": 9,
+            "pronunciation": "[N OW1 B AH0 D IY0]",
+            "conditioned_text": "This was important, but \u2014[N OW1 B AH0 D IY0]\u2014 understood why.",
+            "selected_candidate": 2,
+            "fixed_tokens_unchanged": true,
+            "source_duration_seconds": 0.26,
+            "selected_duration_seconds": 0.3400000000000001,
+            "prominence_change_db": -0.7251850620668634,
+            "pitch_slope_change_semitones": 0.23944908685681998
+          }
+        }
+      ],
+      "baseline": "00_baseline.wav",
+      "baseline_sha256": "5e1ce150112fcffdb2becfcfa1824e7fe3584fc9a80640239f8a315cfd1e4d7c"
+    }
+  ],
+  "native_bracket_case": {
+    "case_id": "genuine_native_brackets",
+    "variants": [
+      {
+        "id": "plain",
+        "generation_text": "The final signature was genuine, and everyone knew it.",
+        "audio": "plain.wav",
+        "audio_sha256": "5b967f132c58bc3ddfe626576f68d96037848a0631996a22ed85bdab5c5ef155",
+        "transcript": "The final signature was genuine and everyone knew it.",
+        "normalized_words": [
+          "the",
+          "final",
+          "signature",
+          "was",
+          "genuine",
+          "and",
+          "everyone",
+          "knew",
+          "it"
+        ]
+      },
+      {
+        "id": "cmu_primary",
+        "generation_text": "The final signature was [JH EH1 N Y AH0 W AH0 N], and everyone knew it.",
+        "audio": "cmu_primary.wav",
+        "audio_sha256": "0c7eca29a6a2f505f761674974871f397802347224b76a568521024d2f67f224",
+        "transcript": "The final signature was genuine, and everyone knew it.",
+        "normalized_words": [
+          "the",
+          "final",
+          "signature",
+          "was",
+          "genuine",
+          "and",
+          "everyone",
+          "knew",
+          "it"
+        ]
+      },
+      {
+        "id": "cmu_alternate",
+        "generation_text": "The final signature was [JH EH1 N Y UW1 W AY2 N], and everyone knew it.",
+        "audio": "cmu_alternate.wav",
+        "audio_sha256": "32805d4104cf403866fa564effb52d2cce0a2c100c4d82c94226a4b4f27af5d5",
+        "transcript": "The final signature was genuine, and everyone knew it.",
+        "normalized_words": [
+          "the",
+          "final",
+          "signature",
+          "was",
+          "genuine",
+          "and",
+          "everyone",
+          "knew",
+          "it"
+        ]
+      }
+    ]
+  }
+}

--- a/reports/narration_control_results.json
+++ b/reports/narration_control_results.json
@@ -1,0 +1,1673 @@
+{
+  "format": "omnivoice_single_reference_narration_smoke_v1",
+  "experiment_revision": "2aa39933b4002d2951df115c9363781d1a9f58d0",
+  "model_revision": "c5fdb5ccb189668d56333f77ba2629f4cd7535f4",
+  "aligner_revision": "d1d751a5f8271d482d14ca55d9e2deeebbae577f",
+  "single_reference": true,
+  "reference_switching": false,
+  "reference_basename": "explaining_sub_11s_24k.wav",
+  "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+  "num_step": 128,
+  "candidates": 3,
+  "runtime_seconds": 141.24918880999758,
+  "runtime": {
+    "python": "3.11.14",
+    "torch": "2.8.0+cu128",
+    "cuda": "12.8",
+    "gpu": "NVIDIA GeForce RTX 4070 SUPER"
+  },
+  "automated_pass": true,
+  "listening_status": "manual review pending",
+  "shared_baseline": "outputs/narration_controls/acceptance/shared_baseline.wav",
+  "cases": [
+    {
+      "case_id": "baseline",
+      "source_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [],
+      "audio": "outputs/narration_controls/acceptance/baseline.wav",
+      "audio_sha256": "024481c3c1f0ca59aead7321ee266e032b066ae9b5b532976d7b0148958c0d39",
+      "runtime_seconds": 5.973691206003423,
+      "gpu_peak_memory_bytes": 2198793216,
+      "baseline_frames": 110,
+      "final_frames": 110,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "metrics": null,
+      "checks": {
+        "word_sequence_matches": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 110,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": []
+      }
+    },
+    {
+      "case_id": "rate_slow",
+      "source_text": "<rate value=\"0.85\">The mechanism looked ordinary.</rate> But the hidden timing changed everything.",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "rate",
+          "start_char": 0,
+          "end_char": 30,
+          "value": 0.85,
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/rate_slow.wav",
+      "audio_sha256": "e6e068c22924a8705245b7d92aed81bac22253c1ed33f96058356ff99413d1a0",
+      "runtime_seconds": 20.284779818997777,
+      "gpu_peak_memory_bytes": 2201249792,
+      "baseline_frames": 110,
+      "final_frames": 117,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary but the hidden timing changed everything",
+      "metrics": {
+        "kind": "rate",
+        "value": 0.85,
+        "source_frames": 41,
+        "target_frames": 48,
+        "source_duration_seconds": 1.64,
+        "selected_duration_seconds": 1.92,
+        "target_duration_seconds": 1.92,
+        "duration_error_seconds": 0.0,
+        "source_prominence_db": 1.4526835937895832,
+        "selected_prominence_db": 0.5730838475925744,
+        "prominence_change_db": -0.8795997461970089,
+        "source_pitch_slope_semitones": -2.4703284354000576,
+        "selected_pitch_slope_semitones": -12.685727028332874,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.5470085740089417
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "duration_within_150ms": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 117,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary but the hidden timing changed everything",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "rate",
+              "start_char": 0,
+              "end_char": 30,
+              "value": 0.85,
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              0,
+              41
+            ],
+            "source_frames": 41,
+            "target_frames": 48,
+            "source_metrics": {
+              "first_word_index": 0,
+              "last_word_index": 3,
+              "start_seconds": 0.0,
+              "end_seconds": 1.64,
+              "duration_seconds": 1.64,
+              "rms_db": -17.896037828328765,
+              "pitch_slope_semitones": -2.4703284354000576,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": 1.4526835937895832
+            },
+            "inpaint_window": [
+              0,
+              46
+            ],
+            "new_core_span": [
+              0,
+              48
+            ],
+            "selected_candidate": 2,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 99.76,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.5470085740089417,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.94,
+                  "duration_seconds": 1.94,
+                  "rms_db": -18.602201451673317,
+                  "pitch_slope_semitones": -14.955731302112799,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.603613420643644,
+                  "prominence_db": 1.0014119689703271,
+                  "target_duration_seconds": 1.92,
+                  "duration_error_seconds": 0.020000000000000018
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 99.76,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.5470085740089417,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.9,
+                  "duration_seconds": 1.9,
+                  "rms_db": -18.035517183000525,
+                  "pitch_slope_semitones": -0.6136654174193157,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.349822929313852,
+                  "prominence_db": 1.3143057463133268,
+                  "target_duration_seconds": 1.92,
+                  "duration_error_seconds": 0.020000000000000018
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 100.0,
+                "transcript": "The mechanism looked ordinary but the hidden timing changed everything",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.5470085740089417,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.92,
+                  "duration_seconds": 1.92,
+                  "rms_db": -19.49665234164515,
+                  "pitch_slope_semitones": -12.685727028332874,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -20.069736189237723,
+                  "prominence_db": 0.5730838475925744,
+                  "target_duration_seconds": 1.92,
+                  "duration_error_seconds": 0.0
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "rate_fast",
+      "source_text": "<rate value=\"1.20\">The mechanism looked ordinary.</rate> But the hidden timing changed everything.",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "rate",
+          "start_char": 0,
+          "end_char": 30,
+          "value": 1.2,
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/rate_fast.wav",
+      "audio_sha256": "28ef7b4804a513b78308f221682e9d3d14b102b6cdf1c3eeee7f8203df36923e",
+      "runtime_seconds": 18.36582984699635,
+      "gpu_peak_memory_bytes": 2198793216,
+      "baseline_frames": 110,
+      "final_frames": 103,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "metrics": {
+        "kind": "rate",
+        "value": 1.2,
+        "source_frames": 41,
+        "target_frames": 34,
+        "source_duration_seconds": 1.64,
+        "selected_duration_seconds": 1.38,
+        "target_duration_seconds": 1.36,
+        "duration_error_seconds": 0.019999999999999796,
+        "source_prominence_db": 1.4526835937895832,
+        "selected_prominence_db": 1.6180820730414567,
+        "prominence_change_db": 0.16539847925187345,
+        "source_pitch_slope_semitones": -2.4703284354000576,
+        "selected_pitch_slope_semitones": -3.717393967046826,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.6213592290878296
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "duration_within_150ms": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 103,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "rate",
+              "start_char": 0,
+              "end_char": 30,
+              "value": 1.2,
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              0,
+              41
+            ],
+            "source_frames": 41,
+            "target_frames": 34,
+            "source_metrics": {
+              "first_word_index": 0,
+              "last_word_index": 3,
+              "start_seconds": 0.0,
+              "end_seconds": 1.64,
+              "duration_seconds": 1.64,
+              "rms_db": -17.896037828328765,
+              "pitch_slope_semitones": -2.4703284354000576,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": 1.4526835937895832
+            },
+            "inpaint_window": [
+              0,
+              46
+            ],
+            "new_core_span": [
+              0,
+              34
+            ],
+            "selected_candidate": 0,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 99.76,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.6213592290878296,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.38,
+                  "duration_seconds": 1.38,
+                  "rms_db": -17.749288779499466,
+                  "pitch_slope_semitones": -3.717393967046826,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.367370852540922,
+                  "prominence_db": 1.6180820730414567,
+                  "target_duration_seconds": 1.36,
+                  "duration_error_seconds": 0.019999999999999796
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 99.52,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.6213592290878296,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.4,
+                  "duration_seconds": 1.4,
+                  "rms_db": -18.184849765197427,
+                  "pitch_slope_semitones": -2.115007114949346,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.545861747440448,
+                  "prominence_db": 1.3610119822430207,
+                  "target_duration_seconds": 1.36,
+                  "duration_error_seconds": 0.039999999999999813
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 99.76,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.6213592290878296,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.38,
+                  "duration_seconds": 1.38,
+                  "rms_db": -18.168769620253,
+                  "pitch_slope_semitones": -4.401389553051574,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.56440233107077,
+                  "prominence_db": 1.3956327108177717,
+                  "target_duration_seconds": 1.36,
+                  "duration_error_seconds": 0.019999999999999796
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "emphasis_moderate",
+      "source_text": "The mechanism looked ordinary. But the <emphasis strength=\"moderate\">hidden timing</emphasis> changed everything.",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "emphasis",
+          "start_char": 39,
+          "end_char": 52,
+          "value": "moderate",
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/emphasis_moderate.wav",
+      "audio_sha256": "b40f938e41c33fb70fbbd32da4e8edfa194e21b5c89a511daa0b009a86e1cadb",
+      "runtime_seconds": 18.48809348099894,
+      "gpu_peak_memory_bytes": 2199486976,
+      "baseline_frames": 110,
+      "final_frames": 113,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "metrics": {
+        "kind": "emphasis",
+        "value": "moderate",
+        "source_frames": 19,
+        "target_frames": 22,
+        "source_duration_seconds": 0.7400000000000002,
+        "selected_duration_seconds": 0.7200000000000002,
+        "target_duration_seconds": 0.88,
+        "duration_error_seconds": 0.1599999999999998,
+        "source_prominence_db": 1.1372213232517474,
+        "selected_prominence_db": 1.747919560465757,
+        "prominence_change_db": 0.6106982372140095,
+        "source_pitch_slope_semitones": -0.6945700573803943,
+        "selected_pitch_slope_semitones": -2.6236832726007395,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.7168141603469849
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "codec_span_expanded": true,
+        "emphasis_proxy_detected": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 113,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "emphasis",
+              "start_char": 39,
+              "end_char": 52,
+              "value": "moderate",
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              62,
+              81
+            ],
+            "source_frames": 19,
+            "target_frames": 22,
+            "source_metrics": {
+              "first_word_index": 6,
+              "last_word_index": 7,
+              "start_seconds": 2.5,
+              "end_seconds": 3.24,
+              "duration_seconds": 0.7400000000000002,
+              "rms_db": -18.2115000988666,
+              "pitch_slope_semitones": -0.6945700573803943,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": 1.1372213232517474
+            },
+            "inpaint_window": [
+              57,
+              86
+            ],
+            "new_core_span": [
+              62,
+              84
+            ],
+            "selected_candidate": 1,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 98.65690770737201,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.7168141603469849,
+                "metrics": {
+                  "first_word_index": 6,
+                  "last_word_index": 7,
+                  "start_seconds": 2.5,
+                  "end_seconds": 3.2,
+                  "duration_seconds": 0.7000000000000002,
+                  "rms_db": -18.95851783239238,
+                  "pitch_slope_semitones": -0.9952383041697264,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.775425539764395,
+                  "prominence_db": 0.8169077073720139,
+                  "target_duration_seconds": 0.88,
+                  "duration_error_seconds": 0.17999999999999983
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 99.82791956046576,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.7168141603469849,
+                "metrics": {
+                  "first_word_index": 6,
+                  "last_word_index": 7,
+                  "start_seconds": 2.5,
+                  "end_seconds": 3.22,
+                  "duration_seconds": 0.7200000000000002,
+                  "rms_db": -17.98717098505864,
+                  "pitch_slope_semitones": -2.6236832726007395,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.735090545524397,
+                  "prominence_db": 1.747919560465757,
+                  "target_duration_seconds": 0.88,
+                  "duration_error_seconds": 0.1599999999999998
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 99.55135790204068,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.7168141603469849,
+                "metrics": {
+                  "first_word_index": 6,
+                  "last_word_index": 7,
+                  "start_seconds": 2.48,
+                  "end_seconds": 3.22,
+                  "duration_seconds": 0.7400000000000002,
+                  "rms_db": -18.495842220818332,
+                  "pitch_slope_semitones": -1.2829830193563896,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.727200122858996,
+                  "prominence_db": 1.2313579020406635,
+                  "target_duration_seconds": 0.88,
+                  "duration_error_seconds": 0.1399999999999998
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "emphasis_strong",
+      "source_text": "The mechanism looked ordinary. But the <emphasis strength=\"strong\">hidden timing</emphasis> changed everything.",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "emphasis",
+          "start_char": 39,
+          "end_char": 52,
+          "value": "strong",
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/emphasis_strong.wav",
+      "audio_sha256": "acf01d49f1d66e7483f49e8a94f8fcfb68f7de246dc91d4665f89db75c72bbf5",
+      "runtime_seconds": 20.273489806000725,
+      "gpu_peak_memory_bytes": 2201546752,
+      "baseline_frames": 110,
+      "final_frames": 117,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "metrics": {
+        "kind": "emphasis",
+        "value": "strong",
+        "source_frames": 19,
+        "target_frames": 26,
+        "source_duration_seconds": 0.7400000000000002,
+        "selected_duration_seconds": 0.8999999999999999,
+        "target_duration_seconds": 1.04,
+        "duration_error_seconds": 0.14000000000000012,
+        "source_prominence_db": 1.1372213232517474,
+        "selected_prominence_db": 0.4392219097992829,
+        "prominence_change_db": -0.6979994134524645,
+        "source_pitch_slope_semitones": -0.6945700573803943,
+        "selected_pitch_slope_semitones": 4.492745120716597,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.692307710647583
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "codec_span_expanded": true,
+        "emphasis_proxy_detected": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 117,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "emphasis",
+              "start_char": 39,
+              "end_char": 52,
+              "value": "strong",
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              62,
+              81
+            ],
+            "source_frames": 19,
+            "target_frames": 26,
+            "source_metrics": {
+              "first_word_index": 6,
+              "last_word_index": 7,
+              "start_seconds": 2.5,
+              "end_seconds": 3.24,
+              "duration_seconds": 0.7400000000000002,
+              "rms_db": -18.2115000988666,
+              "pitch_slope_semitones": -0.6945700573803943,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": 1.1372213232517474
+            },
+            "inpaint_window": [
+              57,
+              86
+            ],
+            "new_core_span": [
+              62,
+              88
+            ],
+            "selected_candidate": 1,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 93.60719342606522,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.692307710647583,
+                "metrics": {
+                  "first_word_index": 6,
+                  "last_word_index": 7,
+                  "start_seconds": 2.52,
+                  "end_seconds": 3.3,
+                  "duration_seconds": 0.7799999999999998,
+                  "rms_db": -22.131879179485196,
+                  "pitch_slope_semitones": -7.490911170415535,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -20.49547589251781,
+                  "prominence_db": -1.6364032869673864,
+                  "target_duration_seconds": 1.04,
+                  "duration_error_seconds": 0.26000000000000023
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 99.19844381959857,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.692307710647583,
+                "metrics": {
+                  "first_word_index": 6,
+                  "last_word_index": 7,
+                  "start_seconds": 2.62,
+                  "end_seconds": 3.52,
+                  "duration_seconds": 0.8999999999999999,
+                  "rms_db": -19.194512289176522,
+                  "pitch_slope_semitones": 4.492745120716597,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.633734198975805,
+                  "prominence_db": 0.4392219097992829,
+                  "target_duration_seconds": 1.04,
+                  "duration_error_seconds": 0.14000000000000012
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 96.06987739406887,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.692307710647583,
+                "metrics": {
+                  "first_word_index": 6,
+                  "last_word_index": 7,
+                  "start_seconds": 2.52,
+                  "end_seconds": 3.4,
+                  "duration_seconds": 0.8799999999999999,
+                  "rms_db": -21.339528037717535,
+                  "pitch_slope_semitones": -2.865442876396781,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -20.334466734751974,
+                  "prominence_db": -1.0050613029655615,
+                  "target_duration_seconds": 1.04,
+                  "duration_error_seconds": 0.16000000000000014
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "intonation_rising",
+      "source_text": "The mechanism looked ordinary. <intonation type=\"rising\">But the hidden timing changed everything.</intonation>",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "intonation",
+          "start_char": 31,
+          "end_char": 72,
+          "value": "rising",
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/intonation_rising.wav",
+      "audio_sha256": "8d39fd30533e9cd8bf8e42bf389cdac26838be71c36ffe369888b6dfb293c7de",
+      "runtime_seconds": 19.219477757003915,
+      "gpu_peak_memory_bytes": 2198823936,
+      "baseline_frames": 110,
+      "final_frames": 110,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "metrics": {
+        "kind": "intonation",
+        "value": "rising",
+        "source_frames": 51,
+        "target_frames": 51,
+        "source_duration_seconds": 1.46,
+        "selected_duration_seconds": 1.3399999999999999,
+        "target_duration_seconds": 1.46,
+        "duration_error_seconds": 0.1200000000000001,
+        "source_prominence_db": -0.7772871204835354,
+        "selected_prominence_db": -0.6867596222177568,
+        "prominence_change_db": 0.09052749826577866,
+        "source_pitch_slope_semitones": -0.8572218931635227,
+        "selected_pitch_slope_semitones": 0.0,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.44545453786849976
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "pitch_direction_matches": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 110,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "intonation",
+              "start_char": 31,
+              "end_char": 72,
+              "value": "rising",
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              54,
+              105
+            ],
+            "source_frames": 51,
+            "target_frames": 51,
+            "source_metrics": {
+              "first_word_index": 7,
+              "last_word_index": 9,
+              "start_seconds": 2.74,
+              "end_seconds": 4.2,
+              "duration_seconds": 1.46,
+              "rms_db": -20.126008542601884,
+              "pitch_slope_semitones": -0.8572218931635227,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": -0.7772871204835354
+            },
+            "inpaint_window": [
+              49,
+              110
+            ],
+            "new_core_span": [
+              54,
+              105
+            ],
+            "selected_candidate": 0,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 98.56,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.44545453786849976,
+                "metrics": {
+                  "first_word_index": 7,
+                  "last_word_index": 9,
+                  "start_seconds": 2.84,
+                  "end_seconds": 4.18,
+                  "duration_seconds": 1.3399999999999999,
+                  "rms_db": -20.368907057786878,
+                  "pitch_slope_semitones": 0.0,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.68214743556912,
+                  "prominence_db": -0.6867596222177568,
+                  "target_duration_seconds": 1.46,
+                  "duration_error_seconds": 0.1200000000000001
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 92.06210082720017,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.44545453786849976,
+                "metrics": {
+                  "first_word_index": 7,
+                  "last_word_index": 9,
+                  "start_seconds": 2.64,
+                  "end_seconds": 4.08,
+                  "duration_seconds": 1.44,
+                  "rms_db": -19.163085901011193,
+                  "pitch_slope_semitones": -2.5659663909332764,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.33738232689509,
+                  "prominence_db": 0.17429642588389527,
+                  "target_duration_seconds": 1.46,
+                  "duration_error_seconds": 0.020000000000000018
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 92.53536139164383,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.44545453786849976,
+                "metrics": {
+                  "first_word_index": 7,
+                  "last_word_index": 9,
+                  "start_seconds": 2.6,
+                  "end_seconds": 4.18,
+                  "duration_seconds": 1.5799999999999996,
+                  "rms_db": -20.741068278191722,
+                  "pitch_slope_semitones": -2.0082128694520556,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.71143028465487,
+                  "prominence_db": -1.029637993536852,
+                  "target_duration_seconds": 1.46,
+                  "duration_error_seconds": 0.11999999999999966
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "intonation_falling",
+      "source_text": "The mechanism looked ordinary. <intonation type=\"falling\">But the hidden timing changed everything.</intonation>",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "intonation",
+          "start_char": 31,
+          "end_char": 72,
+          "value": "falling",
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/intonation_falling.wav",
+      "audio_sha256": "36d4988a73fc3c6a624590c995baf32f640a907feb560d5233c4bd2d7b5a6b58",
+      "runtime_seconds": 19.41069309100567,
+      "gpu_peak_memory_bytes": 2198823936,
+      "baseline_frames": 110,
+      "final_frames": 110,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "metrics": {
+        "kind": "intonation",
+        "value": "falling",
+        "source_frames": 51,
+        "target_frames": 51,
+        "source_duration_seconds": 1.46,
+        "selected_duration_seconds": 1.54,
+        "target_duration_seconds": 1.46,
+        "duration_error_seconds": 0.08000000000000007,
+        "source_prominence_db": -0.7772871204835354,
+        "selected_prominence_db": -0.8684975328992621,
+        "prominence_change_db": -0.0912104124157267,
+        "source_pitch_slope_semitones": -0.8572218931635227,
+        "selected_pitch_slope_semitones": -2.736895657290386,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.44545453786849976
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "pitch_direction_matches": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 110,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "intonation",
+              "start_char": 31,
+              "end_char": 72,
+              "value": "falling",
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              54,
+              105
+            ],
+            "source_frames": 51,
+            "target_frames": 51,
+            "source_metrics": {
+              "first_word_index": 7,
+              "last_word_index": 9,
+              "start_seconds": 2.74,
+              "end_seconds": 4.2,
+              "duration_seconds": 1.46,
+              "rms_db": -20.126008542601884,
+              "pitch_slope_semitones": -0.8572218931635227,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": -0.7772871204835354
+            },
+            "inpaint_window": [
+              49,
+              110
+            ],
+            "new_core_span": [
+              54,
+              105
+            ],
+            "selected_candidate": 0,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 107.25068697187115,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.44545453786849976,
+                "metrics": {
+                  "first_word_index": 7,
+                  "last_word_index": 9,
+                  "start_seconds": 2.58,
+                  "end_seconds": 4.12,
+                  "duration_seconds": 1.54,
+                  "rms_db": -20.106204417802246,
+                  "pitch_slope_semitones": -2.736895657290386,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.237706884902984,
+                  "prominence_db": -0.8684975328992621,
+                  "target_duration_seconds": 1.46,
+                  "duration_error_seconds": 0.08000000000000007
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 100.56762350298207,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.44545453786849976,
+                "metrics": {
+                  "first_word_index": 7,
+                  "last_word_index": 9,
+                  "start_seconds": 2.64,
+                  "end_seconds": 4.1,
+                  "duration_seconds": 1.4599999999999995,
+                  "rms_db": -19.935735326514354,
+                  "pitch_slope_semitones": -0.18920783432735755,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.38745252399907,
+                  "prominence_db": -0.5482828025152848,
+                  "target_duration_seconds": 1.46,
+                  "duration_error_seconds": 4.440892098500626e-16
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 101.60784953052345,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.44545453786849976,
+                "metrics": {
+                  "first_word_index": 7,
+                  "last_word_index": 9,
+                  "start_seconds": 2.56,
+                  "end_seconds": 3.9,
+                  "duration_seconds": 1.3399999999999999,
+                  "rms_db": -20.20022030670832,
+                  "pitch_slope_semitones": -1.015949843507816,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.884509222028935,
+                  "prominence_db": -0.3157110846793856,
+                  "target_duration_seconds": 1.46,
+                  "duration_error_seconds": 0.1200000000000001
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "case_id": "aside",
+      "source_text": "<aside>The mechanism looked ordinary.</aside> But the hidden timing changed everything.",
+      "cleaned_text": "The mechanism looked ordinary. But the hidden timing changed everything.",
+      "controls": [
+        {
+          "kind": "aside",
+          "start_char": 0,
+          "end_char": 30,
+          "value": "parenthetical",
+          "source": "explicit"
+        }
+      ],
+      "audio": "outputs/narration_controls/acceptance/aside.wav",
+      "audio_sha256": "cae6acc1086eea6c0a0d49b179b3397250723379d72e4616300c0231fbb9cfb8",
+      "runtime_seconds": 19.229451277999033,
+      "gpu_peak_memory_bytes": 2198793216,
+      "baseline_frames": 110,
+      "final_frames": 106,
+      "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+      "final_transcript": "the mechanism looked ordinary. But the hidden timing changed everything.",
+      "metrics": {
+        "kind": "aside",
+        "value": "parenthetical",
+        "source_frames": 41,
+        "target_frames": 37,
+        "source_duration_seconds": 1.64,
+        "selected_duration_seconds": 1.5,
+        "target_duration_seconds": 1.48,
+        "duration_error_seconds": 0.020000000000000018,
+        "source_prominence_db": 1.4526835937895832,
+        "selected_prominence_db": 0.0941698613972477,
+        "prominence_change_db": -1.3585137323923355,
+        "source_pitch_slope_semitones": -2.4703284354000576,
+        "selected_pitch_slope_semitones": -2.1723126625614335,
+        "fixed_tokens_unchanged": true,
+        "fixed_token_fraction": 0.6037735939025879
+      },
+      "checks": {
+        "word_sequence_matches": true,
+        "fixed_tokens_unchanged": true,
+        "delivery_faster": true,
+        "prominence_not_increased": true
+      },
+      "automated_pass": true,
+      "controller_report": {
+        "format": "omnivoice_single_reference_narration_v1",
+        "single_reference": true,
+        "reference_switching": false,
+        "seed": 1234,
+        "num_step": 128,
+        "candidate_count": 3,
+        "baseline_frames": 110,
+        "final_frames": 106,
+        "baseline_transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+        "final_transcript": "the mechanism looked ordinary. But the hidden timing changed everything.",
+        "final_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "expected_normalized_words": [
+          "the",
+          "mechanism",
+          "looked",
+          "ordinary",
+          "but",
+          "the",
+          "hidden",
+          "timing",
+          "changed",
+          "everything"
+        ],
+        "word_sequence_matches": true,
+        "controls": [
+          {
+            "control": {
+              "kind": "aside",
+              "start_char": 0,
+              "end_char": 30,
+              "value": "parenthetical",
+              "source": "explicit"
+            },
+            "source_frame_span": [
+              0,
+              41
+            ],
+            "source_frames": 41,
+            "target_frames": 37,
+            "source_metrics": {
+              "first_word_index": 0,
+              "last_word_index": 3,
+              "start_seconds": 0.0,
+              "end_seconds": 1.64,
+              "duration_seconds": 1.64,
+              "rms_db": -17.896037828328765,
+              "pitch_slope_semitones": -2.4703284354000576,
+              "word_match_ratio": 1.0,
+              "whole_rms_db": -19.34872142211835,
+              "prominence_db": 1.4526835937895832
+            },
+            "inpaint_window": [
+              0,
+              46
+            ],
+            "new_core_span": [
+              0,
+              37
+            ],
+            "selected_candidate": 0,
+            "candidates": [
+              {
+                "candidate": 0,
+                "seed": 1334,
+                "score": 99.61874520790414,
+                "transcript": "the mechanism looked ordinary. But the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.6037735939025879,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.5,
+                  "duration_seconds": 1.5,
+                  "rms_db": -20.340842578228944,
+                  "pitch_slope_semitones": -2.1723126625614335,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -20.435012439626192,
+                  "prominence_db": 0.0941698613972477,
+                  "target_duration_seconds": 1.48,
+                  "duration_error_seconds": 0.020000000000000018
+                }
+              },
+              {
+                "candidate": 1,
+                "seed": 1335,
+                "score": 97.60184530602612,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.6037735939025879,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.5,
+                  "duration_seconds": 1.5,
+                  "rms_db": -17.9946591878615,
+                  "pitch_slope_semitones": -4.525891189169039,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.43342898384409,
+                  "prominence_db": 1.4387697959825907,
+                  "target_duration_seconds": 1.48,
+                  "duration_error_seconds": 0.020000000000000018
+                }
+              },
+              {
+                "candidate": 2,
+                "seed": 1336,
+                "score": 97.45543920017624,
+                "transcript": "The mechanism looked ordinary, but the hidden timing changed everything.",
+                "normalized_words": [
+                  "the",
+                  "mechanism",
+                  "looked",
+                  "ordinary",
+                  "but",
+                  "the",
+                  "hidden",
+                  "timing",
+                  "changed",
+                  "everything"
+                ],
+                "fixed_tokens_unchanged": true,
+                "fixed_token_fraction": 0.6037735939025879,
+                "metrics": {
+                  "first_word_index": 0,
+                  "last_word_index": 3,
+                  "start_seconds": 0.0,
+                  "end_seconds": 1.46,
+                  "duration_seconds": 1.46,
+                  "rms_db": -17.916526891722913,
+                  "pitch_slope_semitones": -2.009482485679877,
+                  "word_match_ratio": 1.0,
+                  "alignment_failed": false,
+                  "whole_rms_db": -19.45290075827209,
+                  "prominence_db": 1.5363738665491766,
+                  "target_duration_seconds": 1.48,
+                  "duration_error_seconds": 0.020000000000000018
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/reports/pause_smoke_results.json
+++ b/reports/pause_smoke_results.json
@@ -2,7 +2,7 @@
   "format": "omnivoice_native_pause_smoke_v1",
   "preset": "acceptance",
   "source_revision": "3d2bd9d07bbe8d16c2439745b0ded450dc41e215",
-  "experiment_revision": "dc21d796df0ade536d728e9607b3c6d814f73eb7",
+  "experiment_revision": "b7724f0c9775b3e03e25b4d8a3aaa483770bb981",
   "model_revision": "c5fdb5ccb189668d56333f77ba2629f4cd7535f4",
   "aligner_revision": "d1d751a5f8271d482d14ca55d9e2deeebbae577f",
   "python": "Python 3.11.14",
@@ -11,9 +11,10 @@
   "gpu": "NVIDIA GeForce RTX 4070 SUPER",
   "num_step": 128,
   "seed": 1234,
+  "one_pass_automated_pass": false,
   "automated_pass": false,
   "listening_status": "manual review pending",
-  "decision": "two-pass required",
+  "decision": "latent-pause approach failed",
   "cases": [
     {
       "case_id": "primary_baseline",
@@ -36,7 +37,7 @@
       "duration": null,
       "language": "English",
       "num_step": 128,
-      "runtime_seconds": 3.786480668000877,
+      "runtime_seconds": 4.017067987995688,
       "gpu_peak_memory_bytes": 2203179008,
       "files": {
         "raw": "outputs/pause_smoke/acceptance/primary_baseline_raw.wav",
@@ -44,8 +45,8 @@
         "tokens": "outputs/pause_smoke/acceptance/primary_baseline_tokens.pt"
       },
       "hashes": {
-        "raw_sha256": "6ca63570168d2de5c41c7b98c3e7f7aa03cfccc837722b36078ffb04c8e69247",
-        "final_sha256": "5adf73df74cbaf27b567dee3ecd3f091f8a911afa4b556f582deacee94d7b111",
+        "raw_sha256": "d34306adf73928f8f0ef708bd2dac402b55f15d6d3185ada4211ddb27844abc7",
+        "final_sha256": "b1161889151dcc0fdf9534be11214546f4df4b1330ce88b3ad477fd0e14b64ce",
         "tokens_sha256": "d71b24bb593c4c54b1601c8dc035705e4673041cdfc062f198e2bc9aac8800e7"
       },
       "reference_basename": "explaining_sub_11s_24k.wav",
@@ -394,7 +395,7 @@
       "duration": null,
       "language": "English",
       "num_step": 128,
-      "runtime_seconds": 3.6560297690011794,
+      "runtime_seconds": 3.8856008349976037,
       "gpu_peak_memory_bytes": 2217320960,
       "files": {
         "raw": "outputs/pause_smoke/acceptance/primary_pause_040_raw.wav",
@@ -402,8 +403,8 @@
         "tokens": "outputs/pause_smoke/acceptance/primary_pause_040_tokens.pt"
       },
       "hashes": {
-        "raw_sha256": "9adf00db6b4f4a845d46800a666825df7228662d0cb79066048136b00c8b3893",
-        "final_sha256": "61065934946253018b5ebbcb4d1d2c50c5537252bdbb20772374623d7ea4e8c5",
+        "raw_sha256": "8a82e8ed90e3ce7688f7b397d77bb6e9da5392f0ef687fcf8c0ff80e68723038",
+        "final_sha256": "767039be3404ac18c0994b820d8a8ae6da074e66c8955fadedccbeb6afc41f32",
         "tokens_sha256": "6a685eacaad4ff549f257a7bbb7961888a7a767f7636a52058b9d45f65f0677f"
       },
       "reference_basename": "explaining_sub_11s_24k.wav",
@@ -761,7 +762,7 @@
       "duration": null,
       "language": "English",
       "num_step": 128,
-      "runtime_seconds": 3.726295186999778,
+      "runtime_seconds": 3.891000397998141,
       "gpu_peak_memory_bytes": 2346553856,
       "files": {
         "raw": "outputs/pause_smoke/acceptance/primary_pause_080_raw.wav",
@@ -769,8 +770,8 @@
         "tokens": "outputs/pause_smoke/acceptance/primary_pause_080_tokens.pt"
       },
       "hashes": {
-        "raw_sha256": "496883d1847a1d18b7ee0f0bab87c7e41417f7492ededb9fde1a0a4b4caade10",
-        "final_sha256": "988eb5c710b405ffc73121c88d2ca740ca67ac0616a668a6b04e3c70ca10896f",
+        "raw_sha256": "78da088e73fa04c0fbc5a1f558aca2c4fdffebb441d723b7b6fcf403a960e6ae",
+        "final_sha256": "2143ca6bf269be4c8f04eb6a07001876d1f17d40aa750d92f26e3a4b5898b5c4",
         "tokens_sha256": "e33341931c9e176038c0a18cfa8ab001baa4b897d5210d779e115a9ed6935cfe"
       },
       "reference_basename": "explaining_sub_11s_24k.wav",
@@ -1128,7 +1129,7 @@
       "duration": null,
       "language": "English",
       "num_step": 128,
-      "runtime_seconds": 4.055667208995146,
+      "runtime_seconds": 4.090477807003481,
       "gpu_peak_memory_bytes": 2474312192,
       "files": {
         "raw": "outputs/pause_smoke/acceptance/primary_pause_120_raw.wav",
@@ -1136,8 +1137,8 @@
         "tokens": "outputs/pause_smoke/acceptance/primary_pause_120_tokens.pt"
       },
       "hashes": {
-        "raw_sha256": "b39ab890e01a811e1d2d6625b9e5be65aefc1f0e629762cdb0e45427b34248b8",
-        "final_sha256": "60cc45dd8ab12863f1f675c34bc3e2441b17431a4492813d4f141575a714647a",
+        "raw_sha256": "bd142828a3300896dabd5a4ebba0b6b735edda65245fb5c8972b27bc31756c80",
+        "final_sha256": "2d79795b6105130e14abdbc5769aecd4feeff3c44415f8395c92079e1bd6ee80",
         "tokens_sha256": "43a72b70eb1ab17121c40265918d2d04d1bce3381772351791643686cf1465da"
       },
       "reference_basename": "explaining_sub_11s_24k.wav",
@@ -1485,7 +1486,7 @@
       "duration": null,
       "language": "English",
       "num_step": 128,
-      "runtime_seconds": 5.295256814999448,
+      "runtime_seconds": 5.257309239001188,
       "gpu_peak_memory_bytes": 2270086144,
       "files": {
         "raw": "outputs/pause_smoke/acceptance/secondary_baseline_raw.wav",
@@ -1493,8 +1494,8 @@
         "tokens": "outputs/pause_smoke/acceptance/secondary_baseline_tokens.pt"
       },
       "hashes": {
-        "raw_sha256": "56092dc6555edc69600fc65e31ea3274aef7e5ba439644ad4354f47f905642da",
-        "final_sha256": "2152502d447e2000f6090ebcd02cb3ae00fc676770bd95194a1a876bce9a9920",
+        "raw_sha256": "6e5646c726774d268c51269ef842cf5531b4603efb1a721a3ebf6e367f420c94",
+        "final_sha256": "86d08d1d129b989065c621e4fb9e79717d231d1d1f0b945c93b6c1bf161e82aa",
         "tokens_sha256": "e3c057f4512355cdbb220b65f4bf13fdff25cf9a0f97db9cf179b3e48bf9ab1a"
       },
       "reference_basename": "explaining_24k.wav",
@@ -1939,7 +1940,7 @@
       "duration": null,
       "language": "English",
       "num_step": 128,
-      "runtime_seconds": 5.323387582997384,
+      "runtime_seconds": 5.305939331003174,
       "gpu_peak_memory_bytes": 2346582528,
       "files": {
         "raw": "outputs/pause_smoke/acceptance/secondary_pause_080_raw.wav",
@@ -1947,8 +1948,8 @@
         "tokens": "outputs/pause_smoke/acceptance/secondary_pause_080_tokens.pt"
       },
       "hashes": {
-        "raw_sha256": "d2df88971b63035fdb7458a29f195bfe029965af3792d8d780330aab658a9400",
-        "final_sha256": "8d13b141b92904a71991075e56be231a14a36abe14af2d8b04fd0e4bd9c84c20",
+        "raw_sha256": "201b7920dec7b965693543c62ec9efeb6fd22faf465cc18c53851a3eff51b5c5",
+        "final_sha256": "ff891a44128a9c713e1020fcd016b340523c98c95fe3ac1bfa4d307f7200c96b",
         "tokens_sha256": "2d8b59ab044f18b07489ee78798ea1782d46039ce4ce3c5f62dfbfcb44982da3"
       },
       "reference_basename": "explaining_24k.wav",
@@ -2370,6 +2371,1250 @@
         "no_abnormal_transient_spike": true
       },
       "automated_pass": false
+    }
+  ],
+  "fallback_attempts": [
+    {
+      "case_id": "primary_pause_040_two_pass",
+      "fallback_for_case_id": "primary_pause_040",
+      "group": "primary",
+      "original_text": "The first result looked convincing.<pause:0.40> The second test revealed a hidden timing problem.",
+      "cleaned_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 35,
+            "seconds": 0.4
+          }
+        ]
+      },
+      "requested_pause_seconds": 0.4,
+      "requested_pause_frames": 10,
+      "pause_token_spans": [
+        [
+          55,
+          65
+        ]
+      ],
+      "baseline_insertion_midpoint_seconds": 2.19,
+      "baseline_insertion_frame": 55,
+      "transition_windows": [
+        [
+          50,
+          55
+        ],
+        [
+          65,
+          70
+        ]
+      ],
+      "baseline_tokens_preserved_outside_transitions": true,
+      "target_frames": 139,
+      "raw_samples": 133440,
+      "final_samples": 138240,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 2.4117687629986904,
+      "gpu_peak_memory_bytes": 2209144832,
+      "reference_basename": "explaining_sub_11s_24k.wav",
+      "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/primary_pause_040_two_pass_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/primary_pause_040_two_pass_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/primary_pause_040_two_pass_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "f265c96379eef2592dffcc7f0398b464b068ffe65fc5a55c8dfdb5f3a69fd031",
+        "final_sha256": "070e0d21a97eaa3c3790dea20e2f33ffc1174d9f0ab86cc406289321f39fde28",
+        "tokens_sha256": "77aef488e6f2ea0eceb0aff453131e5939db2eadd052754f8a009506b66d9dc7"
+      },
+      "asr": {
+        "raw": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.44,
+              "probability": 0.603469729423523
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.44,
+              "end": 0.68,
+              "probability": 0.9891080856323242
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.68,
+              "end": 1.08,
+              "probability": 0.9963181018829346
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 1.08,
+              "end": 1.34,
+              "probability": 0.9925655126571655
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.34,
+              "end": 1.92,
+              "probability": 0.9813541173934937
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 2.84,
+              "end": 2.98,
+              "probability": 0.9920830726623535
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 2.98,
+              "end": 3.28,
+              "probability": 0.9886655807495117
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 3.28,
+              "end": 3.68,
+              "probability": 0.996401309967041
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 3.68,
+              "end": 4.0,
+              "probability": 0.9934733510017395
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.0,
+              "end": 4.26,
+              "probability": 0.9979641437530518
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.26,
+              "end": 4.46,
+              "probability": 0.9870485663414001
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.46,
+              "end": 4.92,
+              "probability": 0.9591581225395203
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 4.92,
+              "end": 5.34,
+              "probability": 0.9980915188789368
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.54,
+              "probability": 0.9469908475875854
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.54,
+              "end": 0.76,
+              "probability": 0.9943974018096924
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.76,
+              "end": 1.18,
+              "probability": 0.9979522228240967
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 1.18,
+              "end": 1.44,
+              "probability": 0.9940518736839294
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.44,
+              "end": 2.0,
+              "probability": 0.9850581288337708
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 2.88,
+              "end": 3.08,
+              "probability": 0.9894670844078064
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.08,
+              "end": 3.36,
+              "probability": 0.9896588921546936
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 3.36,
+              "end": 3.78,
+              "probability": 0.9970313310623169
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 3.78,
+              "end": 4.1,
+              "probability": 0.9938856959342957
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.1,
+              "end": 4.38,
+              "probability": 0.9976024031639099
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.38,
+              "end": 4.56,
+              "probability": 0.9874492883682251
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.56,
+              "end": 5.02,
+              "probability": 0.9781998991966248
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 5.02,
+              "end": 5.46,
+              "probability": 0.9980601668357849
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.34,
+            "end": 1.92,
+            "probability": 0.9813541173934937
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 2.84,
+            "end": 2.98,
+            "probability": 0.9920830726623535
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.44,
+            "end": 2.0,
+            "probability": 0.9850581288337708
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 2.88,
+            "end": 3.08,
+            "probability": 0.9894670844078064
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            1.92,
+            2.84
+          ],
+          "asr_word_gap_seconds": 0.9199999999999999,
+          "longest_low_energy_seconds": 0.68,
+          "low_energy_start_seconds": 2.16,
+          "low_energy_end_seconds": 2.84,
+          "minimum_frame_dbfs": -104.62106892304901,
+          "baseline_relative_seconds": 0.39000000000000007
+        },
+        "final": {
+          "anchor_window_seconds": [
+            2.0,
+            2.88
+          ],
+          "asr_word_gap_seconds": 0.8799999999999999,
+          "longest_low_energy_seconds": 0.62,
+          "low_energy_start_seconds": 2.26,
+          "low_energy_end_seconds": 2.88,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.36
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.001259645912796259,
+          "exit_max_abs_delta": 0.01799558848142624,
+          "global_p999_abs_delta": 0.14445121586322784,
+          "abnormal_spike_limit": 0.7222560793161392,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0010200748220086098,
+          "exit_max_abs_delta": 0.0,
+          "global_p999_abs_delta": 0.11707280576229095,
+          "abnormal_spike_limit": 0.5853640288114548,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": true,
+        "final_pause_within_120ms": true,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true,
+        "baseline_tokens_preserved_outside_transitions": true
+      },
+      "automated_pass": true
+    },
+    {
+      "case_id": "primary_pause_120_two_pass",
+      "fallback_for_case_id": "primary_pause_120",
+      "group": "primary",
+      "original_text": "The first result looked convincing.<pause:1.20> The second test revealed a hidden timing problem.",
+      "cleaned_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 35,
+            "seconds": 1.2
+          }
+        ]
+      },
+      "requested_pause_seconds": 1.2,
+      "requested_pause_frames": 30,
+      "pause_token_spans": [
+        [
+          55,
+          85
+        ]
+      ],
+      "baseline_insertion_midpoint_seconds": 2.19,
+      "baseline_insertion_frame": 55,
+      "transition_windows": [
+        [
+          50,
+          55
+        ],
+        [
+          85,
+          90
+        ]
+      ],
+      "baseline_tokens_preserved_outside_transitions": true,
+      "target_frames": 159,
+      "raw_samples": 152640,
+      "final_samples": 157440,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 2.359995644001174,
+      "gpu_peak_memory_bytes": 2216803328,
+      "reference_basename": "explaining_sub_11s_24k.wav",
+      "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/primary_pause_120_two_pass_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/primary_pause_120_two_pass_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/primary_pause_120_two_pass_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "ba38f33e635656da458f99af1ce814d87d37646f7d0f96fa8395a392c61c7867",
+        "final_sha256": "9fd28c7d175ff1db665a2e8b9e3361882e531dbe96300da9e8dad64d4e068088",
+        "tokens_sha256": "d2aa2b2deb3ea3f72429ec5460aa62b4fef0d26dbf03ba143f11c94edeb2227f"
+      },
+      "asr": {
+        "raw": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.46,
+              "probability": 0.5692518949508667
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.46,
+              "end": 0.68,
+              "probability": 0.9893240332603455
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.68,
+              "end": 1.08,
+              "probability": 0.9961041212081909
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 1.08,
+              "end": 1.36,
+              "probability": 0.9926965236663818
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.36,
+              "end": 1.94,
+              "probability": 0.9800328612327576
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 3.54,
+              "end": 3.78,
+              "probability": 0.9915403723716736
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.78,
+              "end": 4.08,
+              "probability": 0.9883193969726562
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 4.08,
+              "end": 4.46,
+              "probability": 0.996379554271698
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 4.46,
+              "end": 4.8,
+              "probability": 0.9938287138938904
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.8,
+              "end": 5.06,
+              "probability": 0.9973247051239014
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 5.06,
+              "end": 5.24,
+              "probability": 0.9898645281791687
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.24,
+              "end": 5.72,
+              "probability": 0.9751594066619873
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 5.72,
+              "end": 6.16,
+              "probability": 0.9977442026138306
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.54,
+              "probability": 0.9112706184387207
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.54,
+              "end": 0.78,
+              "probability": 0.9937141537666321
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.78,
+              "end": 1.18,
+              "probability": 0.9972400665283203
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 1.18,
+              "end": 1.44,
+              "probability": 0.9934797286987305
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.44,
+              "end": 2.04,
+              "probability": 0.9815607070922852
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 3.56,
+              "end": 3.88,
+              "probability": 0.990562915802002
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.88,
+              "end": 4.16,
+              "probability": 0.987362265586853
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 4.16,
+              "end": 4.58,
+              "probability": 0.9955819249153137
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 4.58,
+              "end": 4.9,
+              "probability": 0.9928376078605652
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.9,
+              "end": 5.18,
+              "probability": 0.997405469417572
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 5.18,
+              "end": 5.36,
+              "probability": 0.9886407852172852
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.36,
+              "end": 5.82,
+              "probability": 0.9690421223640442
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 5.82,
+              "end": 6.26,
+              "probability": 0.9978079199790955
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.36,
+            "end": 1.94,
+            "probability": 0.9800328612327576
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 3.54,
+            "end": 3.78,
+            "probability": 0.9915403723716736
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.44,
+            "end": 2.04,
+            "probability": 0.9815607070922852
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 3.56,
+            "end": 3.88,
+            "probability": 0.990562915802002
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            1.94,
+            3.54
+          ],
+          "asr_word_gap_seconds": 1.6,
+          "longest_low_energy_seconds": 1.38,
+          "low_energy_start_seconds": 2.16,
+          "low_energy_end_seconds": 3.54,
+          "minimum_frame_dbfs": -103.99942651246215,
+          "baseline_relative_seconds": 1.0899999999999999
+        },
+        "final": {
+          "anchor_window_seconds": [
+            2.04,
+            3.56
+          ],
+          "asr_word_gap_seconds": 1.52,
+          "longest_low_energy_seconds": 1.3,
+          "low_energy_start_seconds": 2.26,
+          "low_energy_end_seconds": 3.56,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 1.04
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.0015615234151482582,
+          "exit_max_abs_delta": 9.985724318539724e-06,
+          "global_p999_abs_delta": 0.1418382078409195,
+          "abnormal_spike_limit": 0.7091910392045975,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0012688739225268364,
+          "exit_max_abs_delta": 0.0,
+          "global_p999_abs_delta": 0.11467130482196808,
+          "abnormal_spike_limit": 0.5733565241098404,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": true,
+        "final_pause_within_120ms": false,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true,
+        "baseline_tokens_preserved_outside_transitions": true
+      },
+      "automated_pass": false
+    },
+    {
+      "case_id": "secondary_pause_080_two_pass",
+      "fallback_for_case_id": "secondary_pause_080",
+      "group": "secondary",
+      "original_text": "From a distance, the mechanism looks perfectly ordinary.<pause:0.80> But the hidden timing is what makes the whole system work.",
+      "cleaned_text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 56,
+            "seconds": 0.8
+          }
+        ]
+      },
+      "requested_pause_seconds": 0.8,
+      "requested_pause_frames": 20,
+      "pause_token_spans": [
+        [
+          89,
+          109
+        ]
+      ],
+      "baseline_insertion_midpoint_seconds": 3.57,
+      "baseline_insertion_frame": 89,
+      "transition_windows": [
+        [
+          84,
+          89
+        ],
+        [
+          109,
+          114
+        ]
+      ],
+      "baseline_tokens_preserved_outside_transitions": true,
+      "target_frames": 201,
+      "raw_samples": 192960,
+      "final_samples": 197760,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 3.150072137999814,
+      "gpu_peak_memory_bytes": 2277748224,
+      "reference_basename": "explaining_24k.wav",
+      "reference_sha256": "6409ff2b4dd0f0a72249e1754c42df47ecd98c64f9a34cb71df2f52f17a25fad",
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/secondary_pause_080_two_pass_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/secondary_pause_080_two_pass_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/secondary_pause_080_two_pass_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "3159854545c9ca7aa06bf720937abbb4929247079674e4756b15416fbd5ff17e",
+        "final_sha256": "87d2bf5cd6765bb81fd109175d8da928cc2f0ac92e43c26023365d98df1e5b5e",
+        "tokens_sha256": "2f7d17a70d14e4244f9456563a821e329bb192d9a3bd09fe6000d0e7824900cf"
+      },
+      "asr": {
+        "raw": {
+          "text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+          "normalized_words": [
+            "from",
+            "a",
+            "distance",
+            "the",
+            "mechanism",
+            "looks",
+            "perfectly",
+            "ordinary",
+            "but",
+            "the",
+            "hidden",
+            "timing",
+            "is",
+            "what",
+            "makes",
+            "the",
+            "whole",
+            "system",
+            "work"
+          ],
+          "words": [
+            {
+              "word": "From",
+              "normalized": "from",
+              "start": 0.0,
+              "end": 0.36,
+              "probability": 0.8101286888122559
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 0.36,
+              "end": 0.5,
+              "probability": 0.9950982928276062
+            },
+            {
+              "word": "distance,",
+              "normalized": "distance",
+              "start": 0.5,
+              "end": 0.9,
+              "probability": 0.9985578656196594
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 1.4,
+              "end": 1.48,
+              "probability": 0.9971959590911865
+            },
+            {
+              "word": "mechanism",
+              "normalized": "mechanism",
+              "start": 1.48,
+              "end": 1.86,
+              "probability": 0.9828466773033142
+            },
+            {
+              "word": "looks",
+              "normalized": "looks",
+              "start": 1.86,
+              "end": 2.26,
+              "probability": 0.9972233772277832
+            },
+            {
+              "word": "perfectly",
+              "normalized": "perfectly",
+              "start": 2.26,
+              "end": 2.8,
+              "probability": 0.9969086050987244
+            },
+            {
+              "word": "ordinary.",
+              "normalized": "ordinary",
+              "start": 2.8,
+              "end": 3.34,
+              "probability": 0.9994396567344666
+            },
+            {
+              "word": "But",
+              "normalized": "but",
+              "start": 4.56,
+              "end": 4.86,
+              "probability": 0.9845232963562012
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 4.86,
+              "end": 5.06,
+              "probability": 0.9211355447769165
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 5.06,
+              "end": 5.3,
+              "probability": 0.9801780581474304
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.3,
+              "end": 5.8,
+              "probability": 0.9958285689353943
+            },
+            {
+              "word": "is",
+              "normalized": "is",
+              "start": 5.8,
+              "end": 6.08,
+              "probability": 0.996484637260437
+            },
+            {
+              "word": "what",
+              "normalized": "what",
+              "start": 6.08,
+              "end": 6.26,
+              "probability": 0.9991869330406189
+            },
+            {
+              "word": "makes",
+              "normalized": "makes",
+              "start": 6.26,
+              "end": 6.52,
+              "probability": 0.9972730278968811
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 6.52,
+              "end": 6.76,
+              "probability": 0.9944508671760559
+            },
+            {
+              "word": "whole",
+              "normalized": "whole",
+              "start": 6.76,
+              "end": 7.04,
+              "probability": 0.9992431402206421
+            },
+            {
+              "word": "system",
+              "normalized": "system",
+              "start": 7.04,
+              "end": 7.48,
+              "probability": 0.9970038533210754
+            },
+            {
+              "word": "work.",
+              "normalized": "work",
+              "start": 7.48,
+              "end": 7.86,
+              "probability": 0.9983939528465271
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+          "normalized_words": [
+            "from",
+            "a",
+            "distance",
+            "the",
+            "mechanism",
+            "looks",
+            "perfectly",
+            "ordinary",
+            "but",
+            "the",
+            "hidden",
+            "timing",
+            "is",
+            "what",
+            "makes",
+            "the",
+            "whole",
+            "system",
+            "work"
+          ],
+          "words": [
+            {
+              "word": "From",
+              "normalized": "from",
+              "start": 0.0,
+              "end": 0.46,
+              "probability": 0.8741674423217773
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 0.46,
+              "end": 0.6,
+              "probability": 0.9904734492301941
+            },
+            {
+              "word": "distance,",
+              "normalized": "distance",
+              "start": 0.6,
+              "end": 1.0,
+              "probability": 0.9990125894546509
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 1.5,
+              "end": 1.58,
+              "probability": 0.9959021210670471
+            },
+            {
+              "word": "mechanism",
+              "normalized": "mechanism",
+              "start": 1.58,
+              "end": 1.96,
+              "probability": 0.9793606400489807
+            },
+            {
+              "word": "looks",
+              "normalized": "looks",
+              "start": 1.96,
+              "end": 2.36,
+              "probability": 0.9958158135414124
+            },
+            {
+              "word": "perfectly",
+              "normalized": "perfectly",
+              "start": 2.36,
+              "end": 2.9,
+              "probability": 0.9959917664527893
+            },
+            {
+              "word": "ordinary.",
+              "normalized": "ordinary",
+              "start": 2.9,
+              "end": 3.44,
+              "probability": 0.9991081357002258
+            },
+            {
+              "word": "But",
+              "normalized": "but",
+              "start": 4.76,
+              "end": 4.96,
+              "probability": 0.9795829057693481
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 4.96,
+              "end": 5.16,
+              "probability": 0.9247865080833435
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 5.16,
+              "end": 5.4,
+              "probability": 0.9836138486862183
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.4,
+              "end": 5.9,
+              "probability": 0.9936773180961609
+            },
+            {
+              "word": "is",
+              "normalized": "is",
+              "start": 5.9,
+              "end": 6.18,
+              "probability": 0.9950900077819824
+            },
+            {
+              "word": "what",
+              "normalized": "what",
+              "start": 6.18,
+              "end": 6.36,
+              "probability": 0.9988312125205994
+            },
+            {
+              "word": "makes",
+              "normalized": "makes",
+              "start": 6.36,
+              "end": 6.62,
+              "probability": 0.9954032897949219
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 6.62,
+              "end": 6.88,
+              "probability": 0.9913275837898254
+            },
+            {
+              "word": "whole",
+              "normalized": "whole",
+              "start": 6.88,
+              "end": 7.14,
+              "probability": 0.9988095760345459
+            },
+            {
+              "word": "system",
+              "normalized": "system",
+              "start": 7.14,
+              "end": 7.58,
+              "probability": 0.9966867566108704
+            },
+            {
+              "word": "work.",
+              "normalized": "work",
+              "start": 7.58,
+              "end": 7.96,
+              "probability": 0.9974547028541565
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "ordinary.",
+            "normalized": "ordinary",
+            "start": 2.8,
+            "end": 3.34,
+            "probability": 0.9994396567344666
+          },
+          "following_word": {
+            "word": "But",
+            "normalized": "but",
+            "start": 4.56,
+            "end": 4.86,
+            "probability": 0.9845232963562012
+          },
+          "expected_preceding": "ordinary",
+          "expected_following": "but"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "ordinary.",
+            "normalized": "ordinary",
+            "start": 2.9,
+            "end": 3.44,
+            "probability": 0.9991081357002258
+          },
+          "following_word": {
+            "word": "But",
+            "normalized": "but",
+            "start": 4.76,
+            "end": 4.96,
+            "probability": 0.9795829057693481
+          },
+          "expected_preceding": "ordinary",
+          "expected_following": "but"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            3.34,
+            4.56
+          ],
+          "asr_word_gap_seconds": 1.2199999999999998,
+          "longest_low_energy_seconds": 1.0599583333333333,
+          "low_energy_start_seconds": 3.5,
+          "low_energy_end_seconds": 4.559958333333333,
+          "minimum_frame_dbfs": -103.97624048958647,
+          "baseline_relative_seconds": 0.7799583333333333
+        },
+        "final": {
+          "anchor_window_seconds": [
+            3.44,
+            4.76
+          ],
+          "asr_word_gap_seconds": 1.3199999999999998,
+          "longest_low_energy_seconds": 1.16,
+          "low_energy_start_seconds": 3.6,
+          "low_energy_end_seconds": 4.76,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.8399999999999999
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.0014036796055734158,
+          "exit_max_abs_delta": 1.84010586963268e-05,
+          "global_p999_abs_delta": 0.13498206436634064,
+          "abnormal_spike_limit": 0.6749103218317032,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0011874190531671047,
+          "exit_max_abs_delta": 0.0,
+          "global_p999_abs_delta": 0.11326155066490173,
+          "abnormal_spike_limit": 0.5663077533245087,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": true,
+        "final_pause_within_120ms": true,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true,
+        "baseline_tokens_preserved_outside_transitions": true
+      },
+      "automated_pass": true
     }
   ]
 }

--- a/reports/pause_smoke_results.json
+++ b/reports/pause_smoke_results.json
@@ -1,0 +1,2375 @@
+{
+  "format": "omnivoice_native_pause_smoke_v1",
+  "preset": "acceptance",
+  "source_revision": "3d2bd9d07bbe8d16c2439745b0ded450dc41e215",
+  "experiment_revision": "dc21d796df0ade536d728e9607b3c6d814f73eb7",
+  "model_revision": "c5fdb5ccb189668d56333f77ba2629f4cd7535f4",
+  "aligner_revision": "d1d751a5f8271d482d14ca55d9e2deeebbae577f",
+  "python": "Python 3.11.14",
+  "torch": "2.8.0+cu128",
+  "cuda_runtime": "12.8",
+  "gpu": "NVIDIA GeForce RTX 4070 SUPER",
+  "num_step": 128,
+  "seed": 1234,
+  "automated_pass": false,
+  "listening_status": "manual review pending",
+  "decision": "two-pass required",
+  "cases": [
+    {
+      "case_id": "primary_baseline",
+      "group": "primary",
+      "original_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "cleaned_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "canonical_plan": {
+        "pauses": []
+      },
+      "requested_pause_seconds": 0.0,
+      "requested_pause_frames": 0,
+      "pause_token_spans": [],
+      "target_frames": 129,
+      "raw_samples": 123840,
+      "final_samples": 128640,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 3.786480668000877,
+      "gpu_peak_memory_bytes": 2203179008,
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/primary_baseline_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/primary_baseline_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/primary_baseline_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "6ca63570168d2de5c41c7b98c3e7f7aa03cfccc837722b36078ffb04c8e69247",
+        "final_sha256": "5adf73df74cbaf27b567dee3ecd3f091f8a911afa4b556f582deacee94d7b111",
+        "tokens_sha256": "d71b24bb593c4c54b1601c8dc035705e4673041cdfc062f198e2bc9aac8800e7"
+      },
+      "reference_basename": "explaining_sub_11s_24k.wav",
+      "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+      "asr": {
+        "raw": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.44,
+              "probability": 0.7680720090866089
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.44,
+              "end": 0.68,
+              "probability": 0.9923047423362732
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.68,
+              "end": 1.08,
+              "probability": 0.9967334270477295
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 1.08,
+              "end": 1.34,
+              "probability": 0.9924853444099426
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.34,
+              "end": 1.9,
+              "probability": 0.9820961952209473
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 2.48,
+              "end": 2.6,
+              "probability": 0.9904286861419678
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 2.6,
+              "end": 2.88,
+              "probability": 0.9896654486656189
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 2.88,
+              "end": 3.28,
+              "probability": 0.9958802461624146
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 3.28,
+              "end": 3.6,
+              "probability": 0.9931516647338867
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 3.6,
+              "end": 3.86,
+              "probability": 0.9973415732383728
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 3.86,
+              "end": 4.06,
+              "probability": 0.988921046257019
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.06,
+              "end": 4.52,
+              "probability": 0.969077467918396
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 4.52,
+              "end": 4.94,
+              "probability": 0.9976271986961365
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.54,
+              "probability": 0.9471043944358826
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.54,
+              "end": 0.78,
+              "probability": 0.9951794147491455
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.78,
+              "end": 1.18,
+              "probability": 0.9981334805488586
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 1.18,
+              "end": 1.44,
+              "probability": 0.994219183921814
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.44,
+              "end": 2.0,
+              "probability": 0.9841777086257935
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 2.54,
+              "end": 2.7,
+              "probability": 0.9895126223564148
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 2.7,
+              "end": 2.98,
+              "probability": 0.9895867109298706
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 2.98,
+              "end": 3.38,
+              "probability": 0.9974961876869202
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 3.38,
+              "end": 3.7,
+              "probability": 0.9955174326896667
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 3.7,
+              "end": 3.96,
+              "probability": 0.9978742599487305
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 3.96,
+              "end": 4.16,
+              "probability": 0.9904149770736694
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.16,
+              "end": 4.62,
+              "probability": 0.9692562222480774
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 4.62,
+              "end": 5.06,
+              "probability": 0.998241662979126
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.34,
+            "end": 1.9,
+            "probability": 0.9820961952209473
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 2.48,
+            "end": 2.6,
+            "probability": 0.9904286861419678
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.44,
+            "end": 2.0,
+            "probability": 0.9841777086257935
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 2.54,
+            "end": 2.7,
+            "probability": 0.9895126223564148
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            1.9,
+            2.48
+          ],
+          "asr_word_gap_seconds": 0.5800000000000001,
+          "longest_low_energy_seconds": 0.29,
+          "low_energy_start_seconds": 2.19,
+          "low_energy_end_seconds": 2.48,
+          "minimum_frame_dbfs": -104.82085715640429,
+          "baseline_relative_seconds": 0.0
+        },
+        "final": {
+          "anchor_window_seconds": [
+            2.0,
+            2.54
+          ],
+          "asr_word_gap_seconds": 0.54,
+          "longest_low_energy_seconds": 0.26,
+          "low_energy_start_seconds": 2.28,
+          "low_energy_end_seconds": 2.54,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.0
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.002342957304790616,
+          "exit_max_abs_delta": 0.0792938619852066,
+          "global_p999_abs_delta": 0.14816875755786896,
+          "abnormal_spike_limit": 0.7408437877893448,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0026870258152484894,
+          "exit_max_abs_delta": 0.014903039671480656,
+          "global_p999_abs_delta": 0.11922859400510788,
+          "abnormal_spike_limit": 0.5961429700255394,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {},
+      "automated_pass": true
+    },
+    {
+      "case_id": "primary_pause_040",
+      "group": "primary",
+      "original_text": "The first result looked convincing.<pause:0.40> The second test revealed a hidden timing problem.",
+      "cleaned_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 35,
+            "seconds": 0.4
+          }
+        ]
+      },
+      "requested_pause_seconds": 0.4,
+      "requested_pause_frames": 10,
+      "pause_token_spans": [
+        [
+          54,
+          64
+        ]
+      ],
+      "target_frames": 139,
+      "raw_samples": 133440,
+      "final_samples": 135600,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 3.6560297690011794,
+      "gpu_peak_memory_bytes": 2217320960,
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/primary_pause_040_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/primary_pause_040_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/primary_pause_040_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "9adf00db6b4f4a845d46800a666825df7228662d0cb79066048136b00c8b3893",
+        "final_sha256": "61065934946253018b5ebbcb4d1d2c50c5537252bdbb20772374623d7ea4e8c5",
+        "tokens_sha256": "6a685eacaad4ff549f257a7bbb7961888a7a767f7636a52058b9d45f65f0677f"
+      },
+      "reference_basename": "explaining_sub_11s_24k.wav",
+      "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+      "asr": {
+        "raw": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.26,
+              "probability": 0.6130384206771851
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.26,
+              "end": 0.46,
+              "probability": 0.9927375912666321
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.46,
+              "end": 0.84,
+              "probability": 0.9980219602584839
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 0.84,
+              "end": 1.12,
+              "probability": 0.9934132695198059
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.12,
+              "end": 1.68,
+              "probability": 0.9945946335792542
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 2.68,
+              "end": 2.82,
+              "probability": 0.9912870526313782
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 2.82,
+              "end": 3.08,
+              "probability": 0.9885784387588501
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 3.08,
+              "end": 3.42,
+              "probability": 0.9971568584442139
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 3.42,
+              "end": 3.8,
+              "probability": 0.9965568780899048
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 3.8,
+              "end": 4.1,
+              "probability": 0.9980242252349854
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.1,
+              "end": 4.32,
+              "probability": 0.9787060618400574
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.32,
+              "end": 4.78,
+              "probability": 0.9750979542732239
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 4.78,
+              "end": 5.26,
+              "probability": 0.9979382157325745
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.3,
+              "probability": 0.7394185662269592
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.3,
+              "end": 0.5,
+              "probability": 0.9943265318870544
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.5,
+              "end": 0.88,
+              "probability": 0.9984475374221802
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 0.88,
+              "end": 1.16,
+              "probability": 0.9937847852706909
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.16,
+              "end": 1.72,
+              "probability": 0.9948861002922058
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 2.72,
+              "end": 2.86,
+              "probability": 0.9911160469055176
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 2.86,
+              "end": 3.12,
+              "probability": 0.9890698194503784
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 3.12,
+              "end": 3.46,
+              "probability": 0.996737539768219
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 3.46,
+              "end": 3.82,
+              "probability": 0.9953945279121399
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 3.82,
+              "end": 4.14,
+              "probability": 0.9981839060783386
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.14,
+              "end": 4.36,
+              "probability": 0.9831526875495911
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.36,
+              "end": 4.82,
+              "probability": 0.975233793258667
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 4.82,
+              "end": 5.3,
+              "probability": 0.9977049231529236
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.12,
+            "end": 1.68,
+            "probability": 0.9945946335792542
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 2.68,
+            "end": 2.82,
+            "probability": 0.9912870526313782
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.16,
+            "end": 1.72,
+            "probability": 0.9948861002922058
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 2.72,
+            "end": 2.86,
+            "probability": 0.9911160469055176
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            1.68,
+            2.68
+          ],
+          "asr_word_gap_seconds": 1.0000000000000002,
+          "longest_low_energy_seconds": 0.79,
+          "low_energy_start_seconds": 1.89,
+          "low_energy_end_seconds": 2.68,
+          "minimum_frame_dbfs": -104.77139053785207,
+          "baseline_relative_seconds": 0.5
+        },
+        "final": {
+          "anchor_window_seconds": [
+            1.72,
+            2.72
+          ],
+          "asr_word_gap_seconds": 1.0000000000000002,
+          "longest_low_energy_seconds": 0.79,
+          "low_energy_start_seconds": 1.93,
+          "low_energy_end_seconds": 2.72,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.53
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.002130117267370224,
+          "exit_max_abs_delta": 0.024554895237088203,
+          "global_p999_abs_delta": 0.15132834017276764,
+          "abnormal_spike_limit": 0.7566417008638382,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0017415909096598625,
+          "exit_max_abs_delta": 0.020028293132781982,
+          "global_p999_abs_delta": 0.12323509901762009,
+          "abnormal_spike_limit": 0.6161754950881004,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": true,
+        "final_pause_within_120ms": false,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true
+      },
+      "automated_pass": false
+    },
+    {
+      "case_id": "primary_pause_080",
+      "group": "primary",
+      "original_text": "The first result looked convincing.<pause:0.80> The second test revealed a hidden timing problem.",
+      "cleaned_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 35,
+            "seconds": 0.8
+          }
+        ]
+      },
+      "requested_pause_seconds": 0.8,
+      "requested_pause_frames": 20,
+      "pause_token_spans": [
+        [
+          54,
+          74
+        ]
+      ],
+      "target_frames": 149,
+      "raw_samples": 143040,
+      "final_samples": 146880,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 3.726295186999778,
+      "gpu_peak_memory_bytes": 2346553856,
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/primary_pause_080_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/primary_pause_080_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/primary_pause_080_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "496883d1847a1d18b7ee0f0bab87c7e41417f7492ededb9fde1a0a4b4caade10",
+        "final_sha256": "988eb5c710b405ffc73121c88d2ca740ca67ac0616a668a6b04e3c70ca10896f",
+        "tokens_sha256": "e33341931c9e176038c0a18cfa8ab001baa4b897d5210d779e115a9ed6935cfe"
+      },
+      "reference_basename": "explaining_sub_11s_24k.wav",
+      "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+      "asr": {
+        "raw": {
+          "text": "the first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.28,
+              "probability": 0.7974075675010681
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.28,
+              "end": 0.48,
+              "probability": 0.9950404763221741
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.48,
+              "end": 0.86,
+              "probability": 0.9965984225273132
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 0.86,
+              "end": 1.12,
+              "probability": 0.9943844079971313
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.12,
+              "end": 1.68,
+              "probability": 0.9891142845153809
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 3.02,
+              "end": 3.22,
+              "probability": 0.9775525331497192
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.22,
+              "end": 3.54,
+              "probability": 0.9762874245643616
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 3.54,
+              "end": 4.0,
+              "probability": 0.9957557916641235
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 4.0,
+              "end": 4.44,
+              "probability": 0.98847496509552
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.44,
+              "end": 4.76,
+              "probability": 0.9983332753181458
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.76,
+              "end": 5.0,
+              "probability": 0.9756548404693604
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.0,
+              "end": 5.46,
+              "probability": 0.9773328304290771
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 5.46,
+              "end": 5.86,
+              "probability": 0.9970826506614685
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.34,
+              "probability": 0.612982988357544
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.34,
+              "end": 0.54,
+              "probability": 0.9926202297210693
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.54,
+              "end": 0.92,
+              "probability": 0.9979063272476196
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 0.92,
+              "end": 1.18,
+              "probability": 0.9926427006721497
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.18,
+              "end": 1.76,
+              "probability": 0.9911404252052307
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 3.16,
+              "end": 3.28,
+              "probability": 0.9923416376113892
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.28,
+              "end": 3.58,
+              "probability": 0.9858456254005432
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 3.58,
+              "end": 4.04,
+              "probability": 0.9962645173072815
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 4.04,
+              "end": 4.52,
+              "probability": 0.9860509037971497
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.52,
+              "end": 4.82,
+              "probability": 0.9985398054122925
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.82,
+              "end": 5.06,
+              "probability": 0.968578577041626
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.06,
+              "end": 5.54,
+              "probability": 0.9827411770820618
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 5.54,
+              "end": 5.96,
+              "probability": 0.9979496598243713
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.12,
+            "end": 1.68,
+            "probability": 0.9891142845153809
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 3.02,
+            "end": 3.22,
+            "probability": 0.9775525331497192
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.18,
+            "end": 1.76,
+            "probability": 0.9911404252052307
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 3.16,
+            "end": 3.28,
+            "probability": 0.9923416376113892
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            1.68,
+            3.02
+          ],
+          "asr_word_gap_seconds": 1.34,
+          "longest_low_energy_seconds": 1.08,
+          "low_energy_start_seconds": 1.94,
+          "low_energy_end_seconds": 3.02,
+          "minimum_frame_dbfs": -104.47019606731035,
+          "baseline_relative_seconds": 0.79
+        },
+        "final": {
+          "anchor_window_seconds": [
+            1.76,
+            3.16
+          ],
+          "asr_word_gap_seconds": 1.4000000000000001,
+          "longest_low_energy_seconds": 1.16,
+          "low_energy_start_seconds": 2.0,
+          "low_energy_end_seconds": 3.16,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.8999999999999999
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.0016885861987248063,
+          "exit_max_abs_delta": 4.280418579583056e-05,
+          "global_p999_abs_delta": 0.1893031895160675,
+          "abnormal_spike_limit": 0.9465159475803375,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0013683928409591317,
+          "exit_max_abs_delta": 0.06297092884778976,
+          "global_p999_abs_delta": 0.15395966172218323,
+          "abnormal_spike_limit": 0.7697983086109161,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": true,
+        "final_pause_within_120ms": true,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true
+      },
+      "automated_pass": true
+    },
+    {
+      "case_id": "primary_pause_120",
+      "group": "primary",
+      "original_text": "The first result looked convincing.<pause:1.20> The second test revealed a hidden timing problem.",
+      "cleaned_text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 35,
+            "seconds": 1.2
+          }
+        ]
+      },
+      "requested_pause_seconds": 1.2,
+      "requested_pause_frames": 30,
+      "pause_token_spans": [
+        [
+          54,
+          84
+        ]
+      ],
+      "target_frames": 159,
+      "raw_samples": 152640,
+      "final_samples": 156960,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 4.055667208995146,
+      "gpu_peak_memory_bytes": 2474312192,
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/primary_pause_120_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/primary_pause_120_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/primary_pause_120_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "b39ab890e01a811e1d2d6625b9e5be65aefc1f0e629762cdb0e45427b34248b8",
+        "final_sha256": "60cc45dd8ab12863f1f675c34bc3e2441b17431a4492813d4f141575a714647a",
+        "tokens_sha256": "43a72b70eb1ab17121c40265918d2d04d1bce3381772351791643686cf1465da"
+      },
+      "reference_basename": "explaining_sub_11s_24k.wav",
+      "reference_sha256": "26b2c81c114eb0d871287a153104a0810ed349fe66ddad3f5474cac3a377b2c0",
+      "asr": {
+        "raw": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.26,
+              "probability": 0.3612489104270935
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.26,
+              "end": 0.46,
+              "probability": 0.9845291972160339
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.46,
+              "end": 0.84,
+              "probability": 0.9960928559303284
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 0.84,
+              "end": 1.18,
+              "probability": 0.9859646558761597
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.18,
+              "end": 1.8,
+              "probability": 0.9859597682952881
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 3.6,
+              "end": 3.84,
+              "probability": 0.9886924028396606
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.84,
+              "end": 4.08,
+              "probability": 0.9842645525932312
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 4.08,
+              "end": 4.48,
+              "probability": 0.9946797490119934
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 4.48,
+              "end": 4.94,
+              "probability": 0.9846377968788147
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 4.94,
+              "end": 5.28,
+              "probability": 0.9971222281455994
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 5.28,
+              "end": 5.44,
+              "probability": 0.9864046573638916
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.44,
+              "end": 5.94,
+              "probability": 0.9797555208206177
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 5.94,
+              "end": 6.26,
+              "probability": 0.9912370443344116
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "The first result looked convincing. The second test revealed a hidden timing problem.",
+          "normalized_words": [
+            "the",
+            "first",
+            "result",
+            "looked",
+            "convincing",
+            "the",
+            "second",
+            "test",
+            "revealed",
+            "a",
+            "hidden",
+            "timing",
+            "problem"
+          ],
+          "words": [
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 0.0,
+              "end": 0.36,
+              "probability": 0.5732807517051697
+            },
+            {
+              "word": "first",
+              "normalized": "first",
+              "start": 0.36,
+              "end": 0.54,
+              "probability": 0.9865308403968811
+            },
+            {
+              "word": "result",
+              "normalized": "result",
+              "start": 0.54,
+              "end": 0.92,
+              "probability": 0.9977656602859497
+            },
+            {
+              "word": "looked",
+              "normalized": "looked",
+              "start": 0.92,
+              "end": 1.26,
+              "probability": 0.9885092377662659
+            },
+            {
+              "word": "convincing.",
+              "normalized": "convincing",
+              "start": 1.26,
+              "end": 1.9,
+              "probability": 0.9856483936309814
+            },
+            {
+              "word": "The",
+              "normalized": "the",
+              "start": 3.68,
+              "end": 3.92,
+              "probability": 0.9892207980155945
+            },
+            {
+              "word": "second",
+              "normalized": "second",
+              "start": 3.92,
+              "end": 4.16,
+              "probability": 0.9877112507820129
+            },
+            {
+              "word": "test",
+              "normalized": "test",
+              "start": 4.16,
+              "end": 4.56,
+              "probability": 0.9935160875320435
+            },
+            {
+              "word": "revealed",
+              "normalized": "revealed",
+              "start": 4.56,
+              "end": 5.04,
+              "probability": 0.9889188408851624
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 5.04,
+              "end": 5.36,
+              "probability": 0.9970850348472595
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 5.36,
+              "end": 5.52,
+              "probability": 0.9908252358436584
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.52,
+              "end": 6.02,
+              "probability": 0.9800926446914673
+            },
+            {
+              "word": "problem.",
+              "normalized": "problem",
+              "start": 6.02,
+              "end": 6.36,
+              "probability": 0.9927669763565063
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.18,
+            "end": 1.8,
+            "probability": 0.9859597682952881
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 3.6,
+            "end": 3.84,
+            "probability": 0.9886924028396606
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "convincing.",
+            "normalized": "convincing",
+            "start": 1.26,
+            "end": 1.9,
+            "probability": 0.9856483936309814
+          },
+          "following_word": {
+            "word": "The",
+            "normalized": "the",
+            "start": 3.68,
+            "end": 3.92,
+            "probability": 0.9892207980155945
+          },
+          "expected_preceding": "convincing",
+          "expected_following": "the"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            1.8,
+            3.6
+          ],
+          "asr_word_gap_seconds": 1.8,
+          "longest_low_energy_seconds": 1.58,
+          "low_energy_start_seconds": 2.02,
+          "low_energy_end_seconds": 3.6,
+          "minimum_frame_dbfs": -104.01157750597417,
+          "baseline_relative_seconds": 1.29
+        },
+        "final": {
+          "anchor_window_seconds": [
+            1.9,
+            3.68
+          ],
+          "asr_word_gap_seconds": 1.7800000000000002,
+          "longest_low_energy_seconds": 1.59,
+          "low_energy_start_seconds": 2.09,
+          "low_energy_end_seconds": 3.68,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 1.33
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.0017071417532861233,
+          "exit_max_abs_delta": 9.036524716066197e-06,
+          "global_p999_abs_delta": 0.1803865283727646,
+          "abnormal_spike_limit": 0.9019326418638229,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0014430324081331491,
+          "exit_max_abs_delta": 0.0,
+          "global_p999_abs_delta": 0.1460832804441452,
+          "abnormal_spike_limit": 0.730416402220726,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": true,
+        "final_pause_within_120ms": false,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true
+      },
+      "automated_pass": false
+    },
+    {
+      "case_id": "secondary_baseline",
+      "group": "secondary",
+      "original_text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+      "cleaned_text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+      "canonical_plan": {
+        "pauses": []
+      },
+      "requested_pause_seconds": 0.0,
+      "requested_pause_frames": 0,
+      "pause_token_spans": [],
+      "target_frames": 181,
+      "raw_samples": 173760,
+      "final_samples": 178560,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 5.295256814999448,
+      "gpu_peak_memory_bytes": 2270086144,
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/secondary_baseline_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/secondary_baseline_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/secondary_baseline_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "56092dc6555edc69600fc65e31ea3274aef7e5ba439644ad4354f47f905642da",
+        "final_sha256": "2152502d447e2000f6090ebcd02cb3ae00fc676770bd95194a1a876bce9a9920",
+        "tokens_sha256": "e3c057f4512355cdbb220b65f4bf13fdff25cf9a0f97db9cf179b3e48bf9ab1a"
+      },
+      "reference_basename": "explaining_24k.wav",
+      "reference_sha256": "6409ff2b4dd0f0a72249e1754c42df47ecd98c64f9a34cb71df2f52f17a25fad",
+      "asr": {
+        "raw": {
+          "text": "From a distance, the mechanism looks perfectly ordinary, but the hidden timing is what makes the whole system work.",
+          "normalized_words": [
+            "from",
+            "a",
+            "distance",
+            "the",
+            "mechanism",
+            "looks",
+            "perfectly",
+            "ordinary",
+            "but",
+            "the",
+            "hidden",
+            "timing",
+            "is",
+            "what",
+            "makes",
+            "the",
+            "whole",
+            "system",
+            "work"
+          ],
+          "words": [
+            {
+              "word": "From",
+              "normalized": "from",
+              "start": 0.0,
+              "end": 0.36,
+              "probability": 0.8583801984786987
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 0.36,
+              "end": 0.5,
+              "probability": 0.9918943047523499
+            },
+            {
+              "word": "distance,",
+              "normalized": "distance",
+              "start": 0.5,
+              "end": 0.92,
+              "probability": 0.9987695813179016
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 1.42,
+              "end": 1.48,
+              "probability": 0.9953076243400574
+            },
+            {
+              "word": "mechanism",
+              "normalized": "mechanism",
+              "start": 1.48,
+              "end": 1.86,
+              "probability": 0.9788612723350525
+            },
+            {
+              "word": "looks",
+              "normalized": "looks",
+              "start": 1.86,
+              "end": 2.26,
+              "probability": 0.9963839054107666
+            },
+            {
+              "word": "perfectly",
+              "normalized": "perfectly",
+              "start": 2.26,
+              "end": 2.8,
+              "probability": 0.9956353306770325
+            },
+            {
+              "word": "ordinary,",
+              "normalized": "ordinary",
+              "start": 2.8,
+              "end": 3.34,
+              "probability": 0.9991104006767273
+            },
+            {
+              "word": "but",
+              "normalized": "but",
+              "start": 3.8,
+              "end": 4.06,
+              "probability": 0.9884983897209167
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 4.06,
+              "end": 4.26,
+              "probability": 0.9925974607467651
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.26,
+              "end": 4.5,
+              "probability": 0.9848339557647705
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.5,
+              "end": 5.0,
+              "probability": 0.9953303337097168
+            },
+            {
+              "word": "is",
+              "normalized": "is",
+              "start": 5.0,
+              "end": 5.28,
+              "probability": 0.9969174861907959
+            },
+            {
+              "word": "what",
+              "normalized": "what",
+              "start": 5.28,
+              "end": 5.46,
+              "probability": 0.9990372657775879
+            },
+            {
+              "word": "makes",
+              "normalized": "makes",
+              "start": 5.46,
+              "end": 5.72,
+              "probability": 0.9964415431022644
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 5.72,
+              "end": 5.98,
+              "probability": 0.9934410452842712
+            },
+            {
+              "word": "whole",
+              "normalized": "whole",
+              "start": 5.98,
+              "end": 6.24,
+              "probability": 0.9977781176567078
+            },
+            {
+              "word": "system",
+              "normalized": "system",
+              "start": 6.24,
+              "end": 6.68,
+              "probability": 0.9971677660942078
+            },
+            {
+              "word": "work.",
+              "normalized": "work",
+              "start": 6.68,
+              "end": 7.06,
+              "probability": 0.9977383613586426
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "From a distance, the mechanism looks perfectly ordinary, but the hidden timing is what makes the whole system work.",
+          "normalized_words": [
+            "from",
+            "a",
+            "distance",
+            "the",
+            "mechanism",
+            "looks",
+            "perfectly",
+            "ordinary",
+            "but",
+            "the",
+            "hidden",
+            "timing",
+            "is",
+            "what",
+            "makes",
+            "the",
+            "whole",
+            "system",
+            "work"
+          ],
+          "words": [
+            {
+              "word": "From",
+              "normalized": "from",
+              "start": 0.0,
+              "end": 0.46,
+              "probability": 0.9086955785751343
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 0.46,
+              "end": 0.6,
+              "probability": 0.9882806539535522
+            },
+            {
+              "word": "distance,",
+              "normalized": "distance",
+              "start": 0.6,
+              "end": 1.02,
+              "probability": 0.9990890026092529
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 1.54,
+              "end": 1.58,
+              "probability": 0.9939782619476318
+            },
+            {
+              "word": "mechanism",
+              "normalized": "mechanism",
+              "start": 1.58,
+              "end": 1.96,
+              "probability": 0.9780092239379883
+            },
+            {
+              "word": "looks",
+              "normalized": "looks",
+              "start": 1.96,
+              "end": 2.36,
+              "probability": 0.9947279095649719
+            },
+            {
+              "word": "perfectly",
+              "normalized": "perfectly",
+              "start": 2.36,
+              "end": 2.9,
+              "probability": 0.9937875270843506
+            },
+            {
+              "word": "ordinary,",
+              "normalized": "ordinary",
+              "start": 2.9,
+              "end": 3.44,
+              "probability": 0.9988710284233093
+            },
+            {
+              "word": "but",
+              "normalized": "but",
+              "start": 3.94,
+              "end": 4.16,
+              "probability": 0.9893667101860046
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 4.16,
+              "end": 4.36,
+              "probability": 0.9918115139007568
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.36,
+              "end": 4.6,
+              "probability": 0.9886539578437805
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 4.6,
+              "end": 5.12,
+              "probability": 0.9932361245155334
+            },
+            {
+              "word": "is",
+              "normalized": "is",
+              "start": 5.12,
+              "end": 5.38,
+              "probability": 0.9964112639427185
+            },
+            {
+              "word": "what",
+              "normalized": "what",
+              "start": 5.38,
+              "end": 5.56,
+              "probability": 0.9986647367477417
+            },
+            {
+              "word": "makes",
+              "normalized": "makes",
+              "start": 5.56,
+              "end": 5.82,
+              "probability": 0.994722843170166
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 5.82,
+              "end": 6.08,
+              "probability": 0.9889194369316101
+            },
+            {
+              "word": "whole",
+              "normalized": "whole",
+              "start": 6.08,
+              "end": 6.34,
+              "probability": 0.9965528249740601
+            },
+            {
+              "word": "system",
+              "normalized": "system",
+              "start": 6.34,
+              "end": 6.8,
+              "probability": 0.9971150159835815
+            },
+            {
+              "word": "work.",
+              "normalized": "work",
+              "start": 6.8,
+              "end": 7.18,
+              "probability": 0.9957589507102966
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "ordinary,",
+            "normalized": "ordinary",
+            "start": 2.8,
+            "end": 3.34,
+            "probability": 0.9991104006767273
+          },
+          "following_word": {
+            "word": "but",
+            "normalized": "but",
+            "start": 3.8,
+            "end": 4.06,
+            "probability": 0.9884983897209167
+          },
+          "expected_preceding": "ordinary",
+          "expected_following": "but"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "ordinary,",
+            "normalized": "ordinary",
+            "start": 2.9,
+            "end": 3.44,
+            "probability": 0.9988710284233093
+          },
+          "following_word": {
+            "word": "but",
+            "normalized": "but",
+            "start": 3.94,
+            "end": 4.16,
+            "probability": 0.9893667101860046
+          },
+          "expected_preceding": "ordinary",
+          "expected_following": "but"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            3.34,
+            3.8
+          ],
+          "asr_word_gap_seconds": 0.45999999999999996,
+          "longest_low_energy_seconds": 0.28,
+          "low_energy_start_seconds": 3.52,
+          "low_energy_end_seconds": 3.8,
+          "minimum_frame_dbfs": -104.48099882875822,
+          "baseline_relative_seconds": 0.0
+        },
+        "final": {
+          "anchor_window_seconds": [
+            3.44,
+            3.94
+          ],
+          "asr_word_gap_seconds": 0.5,
+          "longest_low_energy_seconds": 0.32,
+          "low_energy_start_seconds": 3.62,
+          "low_energy_end_seconds": 3.94,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.0
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.003413112834095955,
+          "exit_max_abs_delta": 1.862699537014123e-05,
+          "global_p999_abs_delta": 0.1378099024295807,
+          "abnormal_spike_limit": 0.6890495121479034,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0028911083936691284,
+          "exit_max_abs_delta": 0.0,
+          "global_p999_abs_delta": 0.11606813967227936,
+          "abnormal_spike_limit": 0.5803406983613968,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {},
+      "automated_pass": true
+    },
+    {
+      "case_id": "secondary_pause_080",
+      "group": "secondary",
+      "original_text": "From a distance, the mechanism looks perfectly ordinary.<pause:0.80> But the hidden timing is what makes the whole system work.",
+      "cleaned_text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+      "canonical_plan": {
+        "pauses": [
+          {
+            "after_char": 56,
+            "seconds": 0.8
+          }
+        ]
+      },
+      "requested_pause_seconds": 0.8,
+      "requested_pause_frames": 20,
+      "pause_token_spans": [
+        [
+          90,
+          110
+        ]
+      ],
+      "target_frames": 201,
+      "raw_samples": 192960,
+      "final_samples": 187920,
+      "exact_raw_codec_length": true,
+      "fixed_tokens_unchanged": true,
+      "seed": 1234,
+      "speed": 1.0,
+      "duration": null,
+      "language": "English",
+      "num_step": 128,
+      "runtime_seconds": 5.323387582997384,
+      "gpu_peak_memory_bytes": 2346582528,
+      "files": {
+        "raw": "outputs/pause_smoke/acceptance/secondary_pause_080_raw.wav",
+        "final": "outputs/pause_smoke/acceptance/secondary_pause_080_final.wav",
+        "tokens": "outputs/pause_smoke/acceptance/secondary_pause_080_tokens.pt"
+      },
+      "hashes": {
+        "raw_sha256": "d2df88971b63035fdb7458a29f195bfe029965af3792d8d780330aab658a9400",
+        "final_sha256": "8d13b141b92904a71991075e56be231a14a36abe14af2d8b04fd0e4bd9c84c20",
+        "tokens_sha256": "2d8b59ab044f18b07489ee78798ea1782d46039ce4ce3c5f62dfbfcb44982da3"
+      },
+      "reference_basename": "explaining_24k.wav",
+      "reference_sha256": "6409ff2b4dd0f0a72249e1754c42df47ecd98c64f9a34cb71df2f52f17a25fad",
+      "asr": {
+        "raw": {
+          "text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+          "normalized_words": [
+            "from",
+            "a",
+            "distance",
+            "the",
+            "mechanism",
+            "looks",
+            "perfectly",
+            "ordinary",
+            "but",
+            "the",
+            "hidden",
+            "timing",
+            "is",
+            "what",
+            "makes",
+            "the",
+            "whole",
+            "system",
+            "work"
+          ],
+          "words": [
+            {
+              "word": "From",
+              "normalized": "from",
+              "start": 0.0,
+              "end": 0.26,
+              "probability": 0.7765002846717834
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 0.26,
+              "end": 0.4,
+              "probability": 0.9950729012489319
+            },
+            {
+              "word": "distance,",
+              "normalized": "distance",
+              "start": 0.4,
+              "end": 0.82,
+              "probability": 0.9989246726036072
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 1.4,
+              "end": 1.48,
+              "probability": 0.9965519905090332
+            },
+            {
+              "word": "mechanism",
+              "normalized": "mechanism",
+              "start": 1.48,
+              "end": 1.84,
+              "probability": 0.9879401922225952
+            },
+            {
+              "word": "looks",
+              "normalized": "looks",
+              "start": 1.84,
+              "end": 2.22,
+              "probability": 0.9965623021125793
+            },
+            {
+              "word": "perfectly",
+              "normalized": "perfectly",
+              "start": 2.22,
+              "end": 2.72,
+              "probability": 0.995524525642395
+            },
+            {
+              "word": "ordinary.",
+              "normalized": "ordinary",
+              "start": 2.72,
+              "end": 3.24,
+              "probability": 0.9994707703590393
+            },
+            {
+              "word": "But",
+              "normalized": "but",
+              "start": 4.42,
+              "end": 4.66,
+              "probability": 0.9892216920852661
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 4.66,
+              "end": 4.82,
+              "probability": 0.9712091088294983
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.82,
+              "end": 5.04,
+              "probability": 0.9773241877555847
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.04,
+              "end": 5.56,
+              "probability": 0.9917984008789062
+            },
+            {
+              "word": "is",
+              "normalized": "is",
+              "start": 5.56,
+              "end": 5.9,
+              "probability": 0.9926723837852478
+            },
+            {
+              "word": "what",
+              "normalized": "what",
+              "start": 5.9,
+              "end": 6.1,
+              "probability": 0.9988981485366821
+            },
+            {
+              "word": "makes",
+              "normalized": "makes",
+              "start": 6.1,
+              "end": 6.3,
+              "probability": 0.9961254000663757
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 6.3,
+              "end": 6.52,
+              "probability": 0.9905161261558533
+            },
+            {
+              "word": "whole",
+              "normalized": "whole",
+              "start": 6.52,
+              "end": 6.72,
+              "probability": 0.9926020503044128
+            },
+            {
+              "word": "system",
+              "normalized": "system",
+              "start": 6.72,
+              "end": 7.04,
+              "probability": 0.9981990456581116
+            },
+            {
+              "word": "work.",
+              "normalized": "work",
+              "start": 7.04,
+              "end": 7.4,
+              "probability": 0.9987552165985107
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        },
+        "final": {
+          "text": "From a distance, the mechanism looks perfectly ordinary. But the hidden timing is what makes the whole system work.",
+          "normalized_words": [
+            "from",
+            "a",
+            "distance",
+            "the",
+            "mechanism",
+            "looks",
+            "perfectly",
+            "ordinary",
+            "but",
+            "the",
+            "hidden",
+            "timing",
+            "is",
+            "what",
+            "makes",
+            "the",
+            "whole",
+            "system",
+            "work"
+          ],
+          "words": [
+            {
+              "word": "From",
+              "normalized": "from",
+              "start": 0.0,
+              "end": 0.3,
+              "probability": 0.8031082153320312
+            },
+            {
+              "word": "a",
+              "normalized": "a",
+              "start": 0.3,
+              "end": 0.44,
+              "probability": 0.9947086572647095
+            },
+            {
+              "word": "distance,",
+              "normalized": "distance",
+              "start": 0.44,
+              "end": 0.84,
+              "probability": 0.9988316893577576
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 1.48,
+              "end": 1.52,
+              "probability": 0.9963006973266602
+            },
+            {
+              "word": "mechanism",
+              "normalized": "mechanism",
+              "start": 1.52,
+              "end": 1.88,
+              "probability": 0.9861400127410889
+            },
+            {
+              "word": "looks",
+              "normalized": "looks",
+              "start": 1.88,
+              "end": 2.26,
+              "probability": 0.9964170455932617
+            },
+            {
+              "word": "perfectly",
+              "normalized": "perfectly",
+              "start": 2.26,
+              "end": 2.78,
+              "probability": 0.9940952062606812
+            },
+            {
+              "word": "ordinary.",
+              "normalized": "ordinary",
+              "start": 2.78,
+              "end": 3.3,
+              "probability": 0.9993153810501099
+            },
+            {
+              "word": "But",
+              "normalized": "but",
+              "start": 4.46,
+              "end": 4.7,
+              "probability": 0.9876141548156738
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 4.7,
+              "end": 4.86,
+              "probability": 0.9659265279769897
+            },
+            {
+              "word": "hidden",
+              "normalized": "hidden",
+              "start": 4.86,
+              "end": 5.08,
+              "probability": 0.9768335819244385
+            },
+            {
+              "word": "timing",
+              "normalized": "timing",
+              "start": 5.08,
+              "end": 5.6,
+              "probability": 0.9922577738761902
+            },
+            {
+              "word": "is",
+              "normalized": "is",
+              "start": 5.6,
+              "end": 5.94,
+              "probability": 0.9923595786094666
+            },
+            {
+              "word": "what",
+              "normalized": "what",
+              "start": 5.94,
+              "end": 6.14,
+              "probability": 0.9988899827003479
+            },
+            {
+              "word": "makes",
+              "normalized": "makes",
+              "start": 6.14,
+              "end": 6.36,
+              "probability": 0.995895266532898
+            },
+            {
+              "word": "the",
+              "normalized": "the",
+              "start": 6.36,
+              "end": 6.56,
+              "probability": 0.9901081323623657
+            },
+            {
+              "word": "whole",
+              "normalized": "whole",
+              "start": 6.56,
+              "end": 6.76,
+              "probability": 0.9933885335922241
+            },
+            {
+              "word": "system",
+              "normalized": "system",
+              "start": 6.76,
+              "end": 7.08,
+              "probability": 0.9982171654701233
+            },
+            {
+              "word": "work.",
+              "normalized": "work",
+              "start": 7.08,
+              "end": 7.44,
+              "probability": 0.9984111785888672
+            }
+          ],
+          "language": "en",
+          "language_probability": 1.0
+        }
+      },
+      "boundary_anchors": {
+        "raw": {
+          "preceding_word": {
+            "word": "ordinary.",
+            "normalized": "ordinary",
+            "start": 2.72,
+            "end": 3.24,
+            "probability": 0.9994707703590393
+          },
+          "following_word": {
+            "word": "But",
+            "normalized": "but",
+            "start": 4.42,
+            "end": 4.66,
+            "probability": 0.9892216920852661
+          },
+          "expected_preceding": "ordinary",
+          "expected_following": "but"
+        },
+        "final": {
+          "preceding_word": {
+            "word": "ordinary.",
+            "normalized": "ordinary",
+            "start": 2.78,
+            "end": 3.3,
+            "probability": 0.9993153810501099
+          },
+          "following_word": {
+            "word": "But",
+            "normalized": "but",
+            "start": 4.46,
+            "end": 4.7,
+            "probability": 0.9876141548156738
+          },
+          "expected_preceding": "ordinary",
+          "expected_following": "but"
+        }
+      },
+      "pause_measurements": {
+        "raw": {
+          "anchor_window_seconds": [
+            3.24,
+            4.42
+          ],
+          "asr_word_gap_seconds": 1.1799999999999997,
+          "longest_low_energy_seconds": 0.95,
+          "low_energy_start_seconds": 3.47,
+          "low_energy_end_seconds": 4.42,
+          "minimum_frame_dbfs": -103.85970945759917,
+          "baseline_relative_seconds": 0.6699999999999999
+        },
+        "final": {
+          "anchor_window_seconds": [
+            3.3,
+            4.46
+          ],
+          "asr_word_gap_seconds": 1.1600000000000001,
+          "longest_low_energy_seconds": 0.95,
+          "low_energy_start_seconds": 3.51,
+          "low_energy_end_seconds": 4.46,
+          "minimum_frame_dbfs": -240.0,
+          "baseline_relative_seconds": 0.6299999999999999
+        }
+      },
+      "transient_metrics": {
+        "raw": {
+          "entry_max_abs_delta": 0.0023641474545001984,
+          "exit_max_abs_delta": 1.621037517907098e-05,
+          "global_p999_abs_delta": 0.13124196231365204,
+          "abnormal_spike_limit": 0.6562098115682602,
+          "abnormal_spike": false
+        },
+        "final": {
+          "entry_max_abs_delta": 0.0020134493242949247,
+          "exit_max_abs_delta": 0.0,
+          "global_p999_abs_delta": 0.11144515126943588,
+          "abnormal_spike_limit": 0.5572257563471794,
+          "abnormal_spike": false
+        }
+      },
+      "word_order_matches_baseline": true,
+      "wer_vs_baseline": 0.0,
+      "pass_checks": {
+        "exact_requested_codec_frames": true,
+        "raw_pause_within_120ms": false,
+        "final_pause_within_120ms": false,
+        "boundary_words_present": true,
+        "word_sequence_matches_baseline": true,
+        "no_boundary_word_omission_or_duplication": true,
+        "fixed_tokens_unchanged": true,
+        "no_abnormal_transient_spike": true
+      },
+      "automated_pass": false
+    }
+  ]
+}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Experiment and validation scripts."""

--- a/scripts/cmu_pronunciation_smoke.py
+++ b/scripts/cmu_pronunciation_smoke.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Generate legacy narration controls with optional CMU conditioning."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+
+from omnivoice import NarrationController, OmniVoice
+from omnivoice.narration import _transcribe
+
+
+MODEL_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/"
+    "models--k2-fsa--OmniVoice/snapshots/"
+    "c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+)
+ALIGNER_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/"
+    "models--Systran--faster-whisper-small.en/snapshots/"
+    "d1d751a5f8271d482d14ca55d9e2deeebbae577f"
+)
+REFERENCE_PATH = Path(
+    "/home/mustafa/Desktop/pythonprojects/gentest/data/tts/clone_sources/"
+    "12_male_american_accent_performance_references/"
+    "explaining_sub_11s_24k.wav"
+)
+REFERENCE_TEXT = (
+    "But through your camera you'll see like a bluish light flickering. "
+    "Because the camera receives the infrared radiation and then it converts "
+    "it into a color humans can see on the screen."
+)
+
+UNEXPECTED = "AH2 N IH0 K S P EH1 K T IH0 D"
+NOBODY_PRIMARY = "N OW1 B AA2 D IY2"
+NOBODY_REDUCED = "N OW1 B AH0 D IY0"
+GENUINE_PRIMARY = "JH EH1 N Y AH0 W AH0 N"
+GENUINE_ALTERNATE = "JH EH1 N Y UW1 W AY2 N"
+
+
+@dataclass(frozen=True)
+class ControlledCase:
+    case_id: str
+    text: str
+    variants: tuple[tuple[str, dict[str, str] | None], ...]
+
+
+CONTROLLED_CASES = (
+    ControlledCase(
+        "unexpected",
+        'This was <emphasis strength="strong">unexpected</emphasis>.',
+        (("legacy", None), ("cmu", {"unexpected": UNEXPECTED})),
+    ),
+    ControlledCase(
+        "nobody",
+        'This was important, but <emphasis strength="strong">nobody</emphasis> '
+        "understood why.",
+        (
+            ("legacy", None),
+            ("cmu_primary", {"nobody": NOBODY_PRIMARY}),
+            ("cmu_reduced", {"nobody": NOBODY_REDUCED}),
+        ),
+    ),
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def selected_metrics(result) -> dict:
+    control = result.report["controls"][0]
+    selected = control["candidates"][control["selected_candidate"]]
+    source = control["source_metrics"]
+    metrics = selected["metrics"]
+    return {
+        "source_frames": control["source_frames"],
+        "target_frames": control["target_frames"],
+        "pronunciation": control["pronunciation"],
+        "conditioned_text": control["conditioned_text"],
+        "selected_candidate": control["selected_candidate"],
+        "fixed_tokens_unchanged": selected["fixed_tokens_unchanged"],
+        "source_duration_seconds": source["duration_seconds"],
+        "selected_duration_seconds": metrics.get("duration_seconds"),
+        "prominence_change_db": metrics.get("prominence_db", 0.0)
+        - source["prominence_db"],
+        "pitch_slope_change_semitones": metrics.get("pitch_slope_semitones", 0.0)
+        - source["pitch_slope_semitones"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-step", type=int, default=128)
+    parser.add_argument("--candidates", type=int, default=3)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--model-path", type=Path, default=MODEL_PATH)
+    parser.add_argument("--aligner-path", type=Path, default=ALIGNER_PATH)
+    parser.add_argument("--reference", type=Path, default=REFERENCE_PATH)
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    output_dir = args.output_dir or (
+        root / "outputs/narration_controls/cmu_pronunciation"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    model = OmniVoice.from_pretrained(
+        str(args.model_path), device_map="cuda:0", dtype=torch.float16
+    )
+    prompt = model.create_voice_clone_prompt(str(args.reference), REFERENCE_TEXT)
+    controller = NarrationController(
+        model,
+        aligner_path=args.aligner_path,
+        local_files_only=True,
+    )
+    report = {
+        "format": "omnivoice_cmu_pronunciation_smoke_v1",
+        "experiment_revision": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True
+        ).strip(),
+        "reference_basename": args.reference.name,
+        "reference_sha256": sha256(args.reference),
+        "reference_switching": False,
+        "num_step": args.num_step,
+        "candidates": args.candidates,
+        "dictionary_source": "CMUdict master and cmudict.0.7a",
+        "listening_status": "manual review pending",
+        "controlled_cases": [],
+    }
+
+    for case in CONTROLLED_CASES:
+        case_dir = output_dir / case.case_id
+        case_dir.mkdir(parents=True, exist_ok=True)
+        case_report = {"case_id": case.case_id, "variants": []}
+        baseline_written = False
+        for variant_id, pronunciations in case.variants:
+            result = controller.generate(
+                case.text,
+                voice_clone_prompt=prompt,
+                num_step=args.num_step,
+                candidates=args.candidates,
+                seed=1234,
+                pronunciations=pronunciations,
+            )
+            if not baseline_written:
+                baseline_path = case_dir / "00_baseline.wav"
+                sf.write(
+                    baseline_path,
+                    result.baseline_audio,
+                    result.sample_rate,
+                    subtype="FLOAT",
+                )
+                case_report["baseline"] = baseline_path.name
+                case_report["baseline_sha256"] = sha256(baseline_path)
+                baseline_written = True
+            audio_path = case_dir / f"{variant_id}.wav"
+            sf.write(audio_path, result.audio, result.sample_rate, subtype="FLOAT")
+            case_report["variants"].append(
+                {
+                    "id": variant_id,
+                    "audio": audio_path.name,
+                    "audio_sha256": sha256(audio_path),
+                    "baseline_transcript": result.report["baseline_transcript"],
+                    "final_transcript": result.report["final_transcript"],
+                    "word_sequence_matches": result.report["word_sequence_matches"],
+                    "metrics": selected_metrics(result),
+                }
+            )
+            print(case.case_id, variant_id, "generated", flush=True)
+        report["controlled_cases"].append(case_report)
+
+    genuine_dir = output_dir / "genuine_native_brackets"
+    genuine_dir.mkdir(parents=True, exist_ok=True)
+    genuine_variants = (
+        ("plain", "genuine"),
+        ("cmu_primary", f"[{GENUINE_PRIMARY}]"),
+        ("cmu_alternate", f"[{GENUINE_ALTERNATE}]"),
+    )
+    genuine_report = {"case_id": "genuine_native_brackets", "variants": []}
+    for variant_id, surface in genuine_variants:
+        text = f"The final signature was {surface}, and everyone knew it."
+        set_seed(1234)
+        audio = model.generate(
+            text=text,
+            voice_clone_prompt=prompt,
+            language="English",
+            num_step=args.num_step,
+        )[0]
+        audio_path = genuine_dir / f"{variant_id}.wav"
+        sf.write(audio_path, audio, model.sampling_rate, subtype="FLOAT")
+        transcript = _transcribe(controller.aligner, audio, model.sampling_rate)
+        genuine_report["variants"].append(
+            {
+                "id": variant_id,
+                "generation_text": text,
+                "audio": audio_path.name,
+                "audio_sha256": sha256(audio_path),
+                "transcript": transcript["text"],
+                "normalized_words": transcript["normalized_words"],
+            }
+        )
+        print("genuine_native_brackets", variant_id, "generated", flush=True)
+    report["native_bracket_case"] = genuine_report
+
+    report_path = output_dir / "cmu_pronunciation_results.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps({"output_dir": str(output_dir), "report": str(report_path)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/narration_control_smoke.py
+++ b/scripts/narration_control_smoke.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Generate single-reference narration-control A/B samples."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import soundfile as sf
+import torch
+
+from omnivoice import NarrationController, OmniVoice
+
+
+MODEL_REVISION = "c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+MODEL_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/"
+    "models--k2-fsa--OmniVoice/snapshots/"
+    "c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+)
+ALIGNER_REVISION = "d1d751a5f8271d482d14ca55d9e2deeebbae577f"
+ALIGNER_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/"
+    "models--Systran--faster-whisper-small.en/snapshots/"
+    "d1d751a5f8271d482d14ca55d9e2deeebbae577f"
+)
+REFERENCE_PATH = Path(
+    "/home/mustafa/Desktop/pythonprojects/gentest/data/tts/clone_sources/"
+    "12_male_american_accent_performance_references/"
+    "explaining_sub_11s_24k.wav"
+)
+REFERENCE_TEXT = (
+    "But through your camera you'll see like a bluish light flickering. "
+    "Because the camera receives the infrared radiation and then it converts "
+    "it into a color humans can see on the screen."
+)
+BASE_TEXT = "The mechanism looked ordinary. But the hidden timing changed everything."
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    case_id: str
+    text: str
+
+
+CASES = (
+    SmokeCase("baseline", BASE_TEXT),
+    SmokeCase(
+        "rate_slow",
+        '<rate value="0.85">The mechanism looked ordinary.</rate> '
+        "But the hidden timing changed everything.",
+    ),
+    SmokeCase(
+        "rate_fast",
+        '<rate value="1.20">The mechanism looked ordinary.</rate> '
+        "But the hidden timing changed everything.",
+    ),
+    SmokeCase(
+        "emphasis_moderate",
+        "The mechanism looked ordinary. But the "
+        '<emphasis strength="moderate">hidden timing</emphasis> '
+        "changed everything.",
+    ),
+    SmokeCase(
+        "emphasis_strong",
+        "The mechanism looked ordinary. But the "
+        '<emphasis strength="strong">hidden timing</emphasis> '
+        "changed everything.",
+    ),
+    SmokeCase(
+        "intonation_rising",
+        "The mechanism looked ordinary. "
+        '<intonation type="rising">But the hidden timing changed everything.</intonation>',
+    ),
+    SmokeCase(
+        "intonation_falling",
+        "The mechanism looked ordinary. "
+        '<intonation type="falling">But the hidden timing changed everything.</intonation>',
+    ),
+    SmokeCase(
+        "aside",
+        "<aside>The mechanism looked ordinary.</aside> "
+        "But the hidden timing changed everything.",
+    ),
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def selected_control_metrics(result) -> dict | None:
+    controls = result.report["controls"]
+    if not controls:
+        return None
+    control = controls[0]
+    selected = control["candidates"][control["selected_candidate"]]
+    source = control["source_metrics"]
+    metrics = selected["metrics"]
+    return {
+        "kind": control["control"]["kind"],
+        "value": control["control"]["value"],
+        "source_frames": control["source_frames"],
+        "target_frames": control["target_frames"],
+        "source_duration_seconds": source["duration_seconds"],
+        "selected_duration_seconds": metrics.get("duration_seconds"),
+        "target_duration_seconds": metrics.get("target_duration_seconds"),
+        "duration_error_seconds": metrics.get("duration_error_seconds"),
+        "source_prominence_db": source["prominence_db"],
+        "selected_prominence_db": metrics.get("prominence_db"),
+        "prominence_change_db": (
+            metrics.get("prominence_db", 0.0) - source["prominence_db"]
+        ),
+        "source_pitch_slope_semitones": source["pitch_slope_semitones"],
+        "selected_pitch_slope_semitones": metrics.get("pitch_slope_semitones"),
+        "fixed_tokens_unchanged": selected["fixed_tokens_unchanged"],
+        "fixed_token_fraction": selected["fixed_token_fraction"],
+    }
+
+
+def checks_for(metrics: dict | None, word_sequence_matches: bool) -> dict:
+    checks = {"word_sequence_matches": word_sequence_matches}
+    if metrics is None:
+        return checks
+    checks["fixed_tokens_unchanged"] = metrics["fixed_tokens_unchanged"]
+    kind = metrics["kind"]
+    if kind == "rate":
+        checks["duration_within_150ms"] = metrics["duration_error_seconds"] <= 0.15
+    elif kind == "emphasis":
+        minimum_extension = 0.04 if metrics["value"] == "moderate" else 0.10
+        duration_extended = metrics["selected_duration_seconds"] >= (
+            metrics["source_duration_seconds"] + minimum_extension
+        )
+        minimum_prominence = 0.5 if metrics["value"] == "moderate" else 1.5
+        prominence_increased = metrics["prominence_change_db"] >= minimum_prominence
+        checks["codec_span_expanded"] = (
+            metrics["target_frames"] > metrics["source_frames"]
+        )
+        checks["emphasis_proxy_detected"] = duration_extended or prominence_increased
+    elif kind == "intonation":
+        slope = metrics["selected_pitch_slope_semitones"]
+        checks["pitch_direction_matches"] = (
+            slope >= 0.0 if metrics["value"] == "rising" else slope <= -0.5
+        )
+    elif kind == "aside":
+        checks["delivery_faster"] = metrics["selected_duration_seconds"] <= (
+            metrics["source_duration_seconds"] - 0.05
+        )
+        checks["prominence_not_increased"] = metrics["prominence_change_db"] <= 0.0
+    return checks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preset", choices=("quick", "acceptance"), default="quick")
+    parser.add_argument("--num-step", type=int)
+    parser.add_argument("--candidates", type=int)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--model-path", type=Path, default=MODEL_PATH)
+    parser.add_argument("--aligner-path", type=Path, default=ALIGNER_PATH)
+    parser.add_argument("--reference", type=Path, default=REFERENCE_PATH)
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=tuple(case.case_id for case in CASES),
+        help="Run only selected case; repeat for multiple cases.",
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    num_step = args.num_step or (32 if args.preset == "quick" else 128)
+    candidates = args.candidates or (1 if args.preset == "quick" else 3)
+    output_dir = args.output_dir or root / "outputs/narration_controls" / args.preset
+    report_path = args.report or output_dir / "narration_control_results.json"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    model = OmniVoice.from_pretrained(
+        str(args.model_path), device_map="cuda:0", dtype=torch.float16
+    )
+    prompt = model.create_voice_clone_prompt(str(args.reference), REFERENCE_TEXT)
+    controller = NarrationController(
+        model,
+        aligner_path=args.aligner_path,
+        local_files_only=True,
+    )
+
+    results = []
+    baseline_written = False
+    smoke_started = time.perf_counter()
+    selected_cases = [
+        case for case in CASES if not args.case or case.case_id in args.case
+    ]
+    for case in selected_cases:
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+        case_started = time.perf_counter()
+        result = controller.generate(
+            case.text,
+            voice_clone_prompt=prompt,
+            num_step=num_step,
+            candidates=candidates,
+            seed=1234,
+        )
+        audio_path = output_dir / f"{case.case_id}.wav"
+        sf.write(audio_path, result.audio, result.sample_rate, subtype="FLOAT")
+        if not baseline_written:
+            baseline_path = output_dir / "shared_baseline.wav"
+            sf.write(
+                baseline_path,
+                result.baseline_audio,
+                result.sample_rate,
+                subtype="FLOAT",
+            )
+            baseline_written = True
+        metrics = selected_control_metrics(result)
+        checks = checks_for(metrics, result.report["word_sequence_matches"])
+        results.append(
+            {
+                "case_id": case.case_id,
+                "source_text": case.text,
+                "cleaned_text": result.plan.text,
+                "controls": [control.__dict__ for control in result.plan.controls],
+                "audio": str(audio_path.resolve().relative_to(root.resolve())),
+                "audio_sha256": sha256(audio_path),
+                "runtime_seconds": time.perf_counter() - case_started,
+                "gpu_peak_memory_bytes": (
+                    torch.cuda.max_memory_allocated()
+                    if torch.cuda.is_available()
+                    else None
+                ),
+                "baseline_frames": result.report["baseline_frames"],
+                "final_frames": result.report["final_frames"],
+                "baseline_transcript": result.report["baseline_transcript"],
+                "final_transcript": result.report["final_transcript"],
+                "metrics": metrics,
+                "checks": checks,
+                "automated_pass": all(checks.values()),
+                "controller_report": result.report,
+            }
+        )
+
+    controlled = [item for item in results if item["controls"]]
+    report = {
+        "format": "omnivoice_single_reference_narration_smoke_v1",
+        "experiment_revision": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True
+        ).strip(),
+        "model_revision": MODEL_REVISION,
+        "aligner_revision": ALIGNER_REVISION,
+        "single_reference": True,
+        "reference_switching": False,
+        "reference_basename": args.reference.name,
+        "reference_sha256": sha256(args.reference),
+        "num_step": num_step,
+        "candidates": candidates,
+        "runtime_seconds": time.perf_counter() - smoke_started,
+        "runtime": {
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "gpu": (
+                torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+            ),
+        },
+        "automated_pass": all(item["automated_pass"] for item in controlled),
+        "listening_status": "manual review pending",
+        "shared_baseline": str(
+            (output_dir / "shared_baseline.wav").resolve().relative_to(root.resolve())
+        ),
+        "cases": results,
+    }
+    report_path.write_text(json.dumps(report, indent=2) + "\n")
+    print(
+        json.dumps(
+            {
+                "report": str(report_path),
+                "automated_pass": report["automated_pass"],
+                "cases": {
+                    item["case_id"]: {
+                        "automated_pass": item["automated_pass"],
+                        "metrics": item["metrics"],
+                    }
+                    for item in results
+                },
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/native_generation_capture.py
+++ b/scripts/native_generation_capture.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Capture OmniVoice generation traces without ASR or external alignment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+import re
+import time
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+
+from omnivoice import OmniVoice
+from omnivoice.models.omnivoice import OmniVoiceGenerationConfig
+
+
+MODEL_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/models--k2-fsa--OmniVoice/"
+    "snapshots/c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+)
+REFERENCE_PATH = Path(
+    "/home/mustafa/Desktop/pythonprojects/gentest/data/tts/clone_sources/"
+    "12_male_american_accent_performance_references/explaining_24k.wav"
+)
+REFERENCE_TEXT = (
+    "To the human eye, the light on the remote will just look blank. "
+    "But through your camera, you'll see like a bluish light flickering. "
+    "Because the camera receives the infrared radiation, and then it converts "
+    "it into a color humans can see on the screen."
+)
+DEFAULT_TEXT = (
+    "Davey's debt begins with a visible balance. Soon, though, Tony is no longer "
+    "collecting cash. He is collecting the business behind it, and the account "
+    "closes only after the store is exhausted."
+)
+WORD_RE = re.compile(r"[A-Za-z0-9]+(?:'[A-Za-z0-9]+)?")
+MODEL_REVISION = "c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def finite_weighted_mean(values: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    valid = np.isfinite(values)
+    weighted = np.where(valid, values * weights[:, None], 0.0)
+    denominator = np.where(valid, weights[:, None], 0.0).sum(axis=0)
+    return np.divide(
+        weighted.sum(axis=0),
+        denominator,
+        out=np.zeros(values.shape[1], dtype=np.float32),
+        where=denominator > 0,
+    )
+
+
+def frame_audio(audio: np.ndarray, frame_count: int, samples_per_frame: int) -> np.ndarray:
+    wanted = frame_count * samples_per_frame
+    if audio.size < wanted:
+        audio = np.pad(audio, (0, wanted - audio.size))
+    return audio[:wanted].reshape(frame_count, samples_per_frame)
+
+
+def pitch_track(audio: np.ndarray, sample_rate: int, frame_count: int) -> np.ndarray:
+    waveform = torch.from_numpy(audio.astype(np.float32, copy=False)).unsqueeze(0)
+    try:
+        pitch = torchaudio.functional.detect_pitch_frequency(
+            waveform,
+            sample_rate,
+            frame_time=1.0 / 25.0,
+            win_length=5,
+            freq_low=70,
+            freq_high=350,
+        ).squeeze(0).cpu().numpy()
+    except RuntimeError:
+        return np.zeros(frame_count, dtype=np.float32)
+    if pitch.size == 0:
+        return np.zeros(frame_count, dtype=np.float32)
+    source = np.linspace(0.0, 1.0, pitch.size)
+    target = np.linspace(0.0, 1.0, frame_count)
+    return np.interp(target, source, pitch).astype(np.float32)
+
+
+def estimated_words(text: str, frame_count: int, estimator) -> list[dict]:
+    cumulative = [0.0]
+    for char in text:
+        cumulative.append(cumulative[-1] + estimator._get_char_weight(char))
+    total = cumulative[-1] or 1.0
+    words = []
+    for index, match in enumerate(WORD_RE.finditer(text)):
+        start_frame = cumulative[match.start()] / total * frame_count
+        end_frame = cumulative[match.end()] / total * frame_count
+        words.append(
+            {
+                "index": index,
+                "text": match.group(),
+                "start_frame": round(start_frame, 3),
+                "end_frame": round(end_frame, 3),
+                "start_seconds": round(start_frame / 25.0, 4),
+                "end_seconds": round(end_frame / 25.0, 4),
+                "source": "duration_estimator",
+            }
+        )
+    return words
+
+
+def punctuation_boundaries(text: str, frame_count: int, estimator) -> list[dict]:
+    cumulative = [0.0]
+    for char in text:
+        cumulative.append(cumulative[-1] + estimator._get_char_weight(char))
+    total = cumulative[-1] or 1.0
+    boundaries = []
+    for index, char in enumerate(text):
+        if char not in ".,;:!?":
+            continue
+        frame = cumulative[index + 1] / total * frame_count
+        boundaries.append(
+            {
+                "character": char,
+                "after_char": index + 1,
+                "frame": round(frame, 3),
+                "seconds": round(frame / 25.0, 4),
+            }
+        )
+    return boundaries
+
+
+def contiguous_regions(mask: np.ndarray, min_frames: int = 2) -> list[tuple[int, int]]:
+    padded = np.pad(mask.astype(np.int8), (1, 1))
+    changes = np.diff(padded)
+    starts = np.flatnonzero(changes == 1)
+    ends = np.flatnonzero(changes == -1)
+    return [
+        (int(start), int(end))
+        for start, end in zip(starts, ends)
+        if end - start >= min_frames
+    ]
+
+
+def pause_candidates(
+    rms_db: np.ndarray,
+    silence_similarity: np.ndarray,
+    punctuation: list[dict],
+) -> tuple[float, list[dict]]:
+    median_rms = float(np.median(rms_db))
+    threshold = min(-40.0, median_rms - 15.0)
+    quiet = rms_db <= threshold
+    silence_like = silence_similarity >= 0.375
+    mask = quiet | (silence_like & (rms_db <= median_rms - 10.0))
+    regions = []
+    for start, end in contiguous_regions(mask, min_frames=2):
+        center = (start + end) / 2.0
+        max_similarity = float(silence_similarity[start:end].max())
+        nearest = min(
+            punctuation,
+            key=lambda item: abs(float(item["frame"]) - center),
+            default=None,
+        )
+        regions.append(
+            {
+                "start_frame": start,
+                "end_frame": end,
+                "start_seconds": round(start / 25.0, 4),
+                "end_seconds": round(end / 25.0, 4),
+                "duration_seconds": round((end - start) / 25.0, 4),
+                "mean_rms_db": round(float(rms_db[start:end].mean()), 3),
+                "max_silence_token_similarity": round(max_similarity, 4),
+                "confidence": (
+                    "codec_confirmed" if max_similarity >= 0.5 else "energy_only"
+                ),
+                "edge": start == 0 or end == rms_db.size,
+                "nearest_estimated_punctuation": nearest,
+                "evidence": "decoded_energy_or_codec_silence_similarity",
+            }
+        )
+    return threshold, regions
+
+
+def round_list(values: np.ndarray, digits: int = 4) -> list[float]:
+    return np.round(values.astype(np.float64), digits).tolist()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--num-step", type=int, default=128)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--model-path", type=Path, default=MODEL_PATH)
+    parser.add_argument("--reference", type=Path, default=REFERENCE_PATH)
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    set_seed(args.seed)
+    torch.cuda.reset_peak_memory_stats()
+    started = time.perf_counter()
+
+    model = OmniVoice.from_pretrained(
+        str(args.model_path), device_map="cuda:0", dtype=torch.float16
+    )
+    prompt = model.create_voice_clone_prompt(str(args.reference), REFERENCE_TEXT)
+    config = OmniVoiceGenerationConfig(num_step=args.num_step)
+    task = model._preprocess_all(
+        text=args.text,
+        language="English",
+        voice_clone_prompt=prompt,
+        preprocess_prompt=config.preprocess_prompt,
+        speed=1.0,
+        duration=None,
+    )
+    trace: list[dict] = []
+    generation_started = time.perf_counter()
+    with torch.inference_mode():
+        tokens = model._generate_iterative(task, config, trace=trace)[0]
+        raw = (
+            model.audio_tokenizer.decode(
+                tokens.to(model.audio_tokenizer.device).unsqueeze(0)
+            )
+            .audio_values[0]
+            .detach()
+            .cpu()
+            .numpy()
+            .squeeze(0)
+        )
+        final = model._decode_and_post_process(
+            tokens,
+            task.ref_rms[0],
+            config,
+            preserve_internal_silence=False,
+        )
+        silence_reference = model._encode_pause_tokens(25, None).detach().cpu()
+    generation_seconds = time.perf_counter() - generation_started
+
+    raw_path = args.output_dir / "raw.wav"
+    final_path = args.output_dir / "final.wav"
+    trace_path = args.output_dir / "trace.npz"
+    sf.write(raw_path, raw, model.sampling_rate, subtype="PCM_16")
+    sf.write(final_path, final, model.sampling_rate, subtype="PCM_16")
+
+    item = trace[0]
+    token_array = tokens.detach().cpu().numpy()
+    frame_count = token_array.shape[-1]
+    codebook_weights = np.asarray(
+        model.config.audio_codebook_weights, dtype=np.float32
+    )
+    codebook_weights /= codebook_weights.sum()
+    silence_array = silence_reference.numpy()
+    matches = token_array[:, :, None] == silence_array[:, None, :]
+    silence_similarity = (matches * codebook_weights[:, None, None]).sum(axis=0).max(axis=1)
+
+    samples_per_frame = model.sampling_rate // model.audio_tokenizer.config.frame_rate
+    frames = frame_audio(raw, frame_count, samples_per_frame)
+    rms = np.sqrt(np.mean(np.square(frames, dtype=np.float64), axis=1))
+    peak = np.max(np.abs(frames), axis=1)
+    rms_db = 20.0 * np.log10(np.maximum(rms, 1e-7))
+    peak_db = 20.0 * np.log10(np.maximum(peak, 1e-7))
+    pitch_hz = pitch_track(raw, model.sampling_rate, frame_count)
+
+    words = estimated_words(args.text, frame_count, model.duration_estimator)
+    punctuation = punctuation_boundaries(args.text, frame_count, model.duration_estimator)
+    threshold, pauses = pause_candidates(rms_db, silence_similarity, punctuation)
+
+    trace_arrays = {
+        key: item[key].numpy()
+        for key in ("unmask_step", "token_logprob", "entropy", "cfg_delta", "fixed", "pause")
+    }
+    unmask = finite_weighted_mean(trace_arrays["unmask_step"].astype(np.float32), codebook_weights)
+    logprob = finite_weighted_mean(trace_arrays["token_logprob"], codebook_weights)
+    entropy = finite_weighted_mean(trace_arrays["entropy"], codebook_weights)
+    cfg_delta = finite_weighted_mean(trace_arrays["cfg_delta"], codebook_weights)
+    strong_internal = [
+        region
+        for region in pauses
+        if region["confidence"] == "codec_confirmed" and not region["edge"]
+    ]
+    strong_mask = np.zeros(frame_count, dtype=bool)
+    for region in strong_internal:
+        strong_mask[region["start_frame"] : region["end_frame"]] = True
+
+    def signal_comparison(values: np.ndarray) -> dict[str, float] | None:
+        if not strong_mask.any() or strong_mask.all():
+            return None
+        return {
+            "pause_mean": round(float(values[strong_mask].mean()), 4),
+            "other_mean": round(float(values[~strong_mask].mean()), 4),
+        }
+
+    np.savez_compressed(
+        trace_path,
+        tokens=token_array.astype(np.uint16),
+        silence_reference=silence_array.astype(np.uint16),
+        **trace_arrays,
+    )
+    report = {
+        "format": "omnivoice_native_generation_capture_v1",
+        "text": args.text,
+        "seed": args.seed,
+        "num_step": args.num_step,
+        "model_revision": MODEL_REVISION,
+        "reference": {
+            "basename": args.reference.name,
+            "sha256": sha256(args.reference),
+        },
+        "provenance": {
+            "whisper_or_asr_used": False,
+            "external_word_aligner_used": False,
+            "word_positions": "OmniVoice RuleDurationEstimator weight projection",
+            "pause_metadata": "exact GenerationTask pause spans; natural pauses are not labeled",
+            "pause_inference": "codec-token silence similarity plus decoded 40 ms RMS",
+            "pitch_measurement": "torchaudio pitch estimate from decoded model audio",
+        },
+        "audio": {
+            "sample_rate": model.sampling_rate,
+            "frame_rate": model.audio_tokenizer.config.frame_rate,
+            "samples_per_frame": samples_per_frame,
+            "raw_file": raw_path.name,
+            "final_file": final_path.name,
+            "raw_sha256": sha256(raw_path),
+            "final_sha256": sha256(final_path),
+            "raw_duration_seconds": round(raw.size / model.sampling_rate, 4),
+            "final_duration_seconds": round(final.size / model.sampling_rate, 4),
+        },
+        "generation": {
+            "target_frames": int(task.target_lens[0]),
+            "generated_frames": frame_count,
+            "codebooks": int(token_array.shape[0]),
+            "fixed_token_count": int(trace_arrays["fixed"].sum()),
+            "explicit_pause_token_count": int(trace_arrays["pause"].sum()),
+            "runtime_seconds": round(generation_seconds, 3),
+            "total_runtime_seconds": round(time.perf_counter() - started, 3),
+            "peak_gpu_memory_mb": round(torch.cuda.max_memory_allocated() / 1024**2, 1),
+        },
+        "word_estimates": words,
+        "punctuation_estimates": punctuation,
+        "pause_detection": {
+            "rms_threshold_db": round(threshold, 3),
+            "minimum_frames": 2,
+            "candidates": pauses,
+            "accuracy_status": "time-local evidence only; word boundary accuracy unverified without alignment",
+        },
+        "native_findings": {
+            "codec_confirmed_internal_pause_candidates": strong_internal,
+            "energy_only_internal_candidate_count": sum(
+                region["confidence"] == "energy_only" and not region["edge"]
+                for region in pauses
+            ),
+            "edge_region_count": sum(region["edge"] for region in pauses),
+            "pause_signal_comparison": {
+                "rms_db": signal_comparison(rms_db),
+                "silence_token_similarity": signal_comparison(silence_similarity),
+                "entropy": signal_comparison(entropy),
+                "cfg_delta": signal_comparison(cfg_delta),
+                "token_logprob": signal_comparison(logprob),
+            },
+            "interpretation": (
+                "Codec-confirmed regions are stronger native-only pause evidence. "
+                "Energy-only regions can be consonant closures or brief articulation gaps."
+            ),
+        },
+        "frames": {
+            "rms_db": round_list(rms_db, 3),
+            "peak_db": round_list(peak_db, 3),
+            "pitch_hz": round_list(pitch_hz, 2),
+            "silence_token_similarity": round_list(silence_similarity, 4),
+            "unmask_step": round_list(unmask, 3),
+            "token_logprob": round_list(logprob, 4),
+            "entropy": round_list(entropy, 4),
+            "cfg_delta": round_list(cfg_delta, 4),
+        },
+        "files": {
+            "trace": trace_path.name,
+        },
+    }
+    report_path = args.output_dir / "capture.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({"ok": True, "report": str(report_path), "audio": str(final_path)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pause_smoke.py
+++ b/scripts/pause_smoke.py
@@ -366,6 +366,164 @@ def generate_case(
     }
 
 
+def merge_windows(windows: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged = []
+    for start, end in sorted(windows):
+        if start >= end:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def generate_two_pass_case(
+    model: OmniVoice,
+    prompt,
+    case: SmokeCase,
+    failed_result: dict,
+    baseline_result: dict,
+    output_dir: Path,
+    num_step: int,
+) -> dict:
+    baseline_tokens = torch.load(
+        baseline_result["files"]["tokens"], map_location=model.device
+    )
+    anchors = baseline_result["boundary_anchors"]["raw"]
+    if anchors is None:
+        raise RuntimeError("Two-pass fallback requires baseline boundary anchors")
+    midpoint_seconds = (
+        anchors["preceding_word"]["end"] + anchors["following_word"]["start"]
+    ) / 2.0
+    insertion_frame = int(np.floor(midpoint_seconds * FRAME_RATE + 0.5))
+    insertion_frame = max(1, min(baseline_tokens.shape[-1] - 1, insertion_frame))
+    pause_frames = int(np.floor(case.requested_pause_seconds * FRAME_RATE + 0.5))
+    pause_tokens = model._encode_pause_tokens(pause_frames, None)
+    template = torch.cat(
+        (
+            baseline_tokens[:, :insertion_frame],
+            pause_tokens,
+            baseline_tokens[:, insertion_frame:],
+        ),
+        dim=-1,
+    )
+
+    transition_windows = merge_windows(
+        [
+            (max(0, insertion_frame - 5), insertion_frame),
+            (
+                insertion_frame + pause_frames,
+                min(template.shape[-1], insertion_frame + pause_frames + 5),
+            ),
+        ]
+    )
+    for start, end in transition_windows:
+        template[:, start:end] = model.config.audio_mask_id
+
+    config = OmniVoiceGenerationConfig(num_step=num_step)
+    task = model._preprocess_all(
+        text=failed_result["cleaned_text"],
+        language="English",
+        voice_clone_prompt=prompt,
+        preprocess_prompt=config.preprocess_prompt,
+        speed=1.0,
+        duration=None,
+    )
+    if task.target_lens[0] != baseline_tokens.shape[-1]:
+        raise RuntimeError("Two-pass baseline token length no longer matches text plan")
+    task.target_lens = [template.shape[-1]]
+    task.target_templates = [template]
+    task.pause_spans = [((insertion_frame, insertion_frame + pause_frames),)]
+    task.controlled = [True]
+
+    set_seed(SEED)
+    torch.cuda.reset_peak_memory_stats()
+    started = time.perf_counter()
+    with torch.inference_mode():
+        tokens = model._generate_iterative(task, config)[0]
+        raw = (
+            model.audio_tokenizer.decode(
+                tokens.to(model.audio_tokenizer.device).unsqueeze(0)
+            )
+            .audio_values[0]
+            .cpu()
+            .numpy()
+            .squeeze(0)
+        )
+        final = model._decode_and_post_process(
+            tokens,
+            task.ref_rms[0],
+            config,
+            preserve_internal_silence=True,
+        )
+    runtime = time.perf_counter() - started
+
+    fallback_id = f"{case.case_id}_two_pass"
+    raw_path = output_dir / f"{fallback_id}_raw.wav"
+    final_path = output_dir / f"{fallback_id}_final.wav"
+    token_path = output_dir / f"{fallback_id}_tokens.pt"
+    sf.write(raw_path, raw, model.sampling_rate, subtype="FLOAT")
+    sf.write(final_path, final, model.sampling_rate, subtype="FLOAT")
+    torch.save(tokens.cpu(), token_path)
+
+    fixed = template != model.config.audio_mask_id
+    fixed_unchanged = bool(torch.equal(tokens[fixed], template[fixed]))
+    left_preserved = bool(
+        torch.equal(
+            tokens[:, : max(0, insertion_frame - 5)],
+            baseline_tokens[:, : max(0, insertion_frame - 5)],
+        )
+    )
+    right_baseline_start = min(baseline_tokens.shape[-1], insertion_frame + 5)
+    right_output_start = right_baseline_start + pause_frames
+    right_preserved = bool(
+        torch.equal(
+            tokens[:, right_output_start:], baseline_tokens[:, right_baseline_start:]
+        )
+    )
+    return {
+        "case_id": fallback_id,
+        "fallback_for_case_id": case.case_id,
+        "group": case.group,
+        "original_text": case.original_text,
+        "cleaned_text": failed_result["cleaned_text"],
+        "canonical_plan": failed_result["canonical_plan"],
+        "requested_pause_seconds": case.requested_pause_seconds,
+        "requested_pause_frames": pause_frames,
+        "pause_token_spans": [[insertion_frame, insertion_frame + pause_frames]],
+        "baseline_insertion_midpoint_seconds": midpoint_seconds,
+        "baseline_insertion_frame": insertion_frame,
+        "transition_windows": [list(window) for window in transition_windows],
+        "baseline_tokens_preserved_outside_transitions": left_preserved
+        and right_preserved,
+        "target_frames": template.shape[-1],
+        "raw_samples": len(raw),
+        "final_samples": len(final),
+        "exact_raw_codec_length": len(raw) == template.shape[-1] * SAMPLES_PER_FRAME,
+        "fixed_tokens_unchanged": fixed_unchanged,
+        "seed": SEED,
+        "speed": 1.0,
+        "duration": None,
+        "language": "English",
+        "num_step": num_step,
+        "runtime_seconds": runtime,
+        "gpu_peak_memory_bytes": torch.cuda.max_memory_allocated(),
+        "reference_basename": case.reference_basename,
+        "reference_sha256": failed_result["reference_sha256"],
+        "files": {
+            "raw": str(raw_path),
+            "final": str(final_path),
+            "tokens": str(token_path),
+        },
+        "hashes": {
+            "raw_sha256": sha256(raw_path),
+            "final_sha256": sha256(final_path),
+            "tokens_sha256": sha256(token_path),
+        },
+    }
+
+
 def add_measurements(aligner: WhisperModel, result: dict) -> None:
     cleaned = result["cleaned_text"]
     pauses = result["canonical_plan"]["pauses"]
@@ -477,6 +635,11 @@ def main() -> None:
     parser.add_argument("--model-path", type=Path, default=MODEL_PATH)
     parser.add_argument("--aligner-path", type=Path, default=ALIGNER_PATH)
     parser.add_argument("--reference-dir", type=Path, default=REFERENCE_DIR)
+    parser.add_argument(
+        "--two-pass-fallback",
+        action="store_true",
+        help="Attempt boundary inpainting only for failed one-pass cases.",
+    )
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
@@ -523,12 +686,60 @@ def main() -> None:
     for result in results:
         add_measurements(aligner, result)
     evaluate_group(results)
-    relative_output_paths(results, root)
 
     controlled = [item for item in results if item["canonical_plan"]["pauses"]]
-    automated_pass = bool(controlled) and all(
+    one_pass_automated_pass = bool(controlled) and all(
         item["automated_pass"] for item in controlled
     )
+    fallback_results = []
+    if args.two_pass_fallback and not one_pass_automated_pass:
+        case_map = {case.case_id: case for case in cases}
+        baselines = {
+            item["group"]: item
+            for item in results
+            if not item["canonical_plan"]["pauses"]
+        }
+        for failed in controlled:
+            if failed["automated_pass"]:
+                continue
+            case = case_map[failed["case_id"]]
+            fallback = generate_two_pass_case(
+                model,
+                prompt_cache[case.reference_basename],
+                case,
+                failed,
+                baselines[case.group],
+                output_dir,
+                num_step,
+            )
+            add_measurements(aligner, fallback)
+            evaluate_group([baselines[case.group], fallback])
+            fallback["pass_checks"]["baseline_tokens_preserved_outside_transitions"] = (
+                fallback["baseline_tokens_preserved_outside_transitions"]
+            )
+            fallback["automated_pass"] = all(fallback["pass_checks"].values())
+            fallback_results.append(fallback)
+
+    fallback_by_case = {item["fallback_for_case_id"]: item for item in fallback_results}
+    automated_pass = bool(controlled) and all(
+        item["automated_pass"]
+        or (
+            item["case_id"] in fallback_by_case
+            and fallback_by_case[item["case_id"]]["automated_pass"]
+        )
+        for item in controlled
+    )
+    if one_pass_automated_pass:
+        decision = "one-pass accepted"
+    elif automated_pass:
+        decision = "two-pass required"
+    elif args.two_pass_fallback:
+        decision = "latent-pause approach failed"
+    else:
+        decision = "two-pass required"
+
+    relative_output_paths(results, root)
+    relative_output_paths(fallback_results, root)
     report = {
         "format": "omnivoice_native_pause_smoke_v1",
         "preset": args.preset,
@@ -544,10 +755,12 @@ def main() -> None:
         "gpu": torch.cuda.get_device_name(0),
         "num_step": num_step,
         "seed": SEED,
+        "one_pass_automated_pass": one_pass_automated_pass,
         "automated_pass": automated_pass,
         "listening_status": "manual review pending",
-        "decision": "one-pass accepted" if automated_pass else "two-pass required",
+        "decision": decision,
         "cases": results,
+        "fallback_attempts": fallback_results,
     }
     report_path.write_text(json.dumps(report, indent=2) + "\n")
     print(
@@ -567,6 +780,18 @@ def main() -> None:
                         ),
                     }
                     for item in results
+                },
+                "fallback_attempts": {
+                    item["case_id"]: {
+                        "automated_pass": item["automated_pass"],
+                        "raw_incremental": item["pause_measurements"]["raw"].get(
+                            "baseline_relative_seconds"
+                        ),
+                        "final_incremental": item["pause_measurements"]["final"].get(
+                            "baseline_relative_seconds"
+                        ),
+                    }
+                    for item in fallback_results
                 },
             },
             indent=2,

--- a/scripts/pause_smoke.py
+++ b/scripts/pause_smoke.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Generate and measure OmniVoice native-pause smoke matrices."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import random
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import jiwer
+import numpy as np
+import soundfile as sf
+import torch
+from faster_whisper import WhisperModel
+
+from omnivoice import OmniVoice, OmniVoiceGenerationConfig
+from omnivoice.controls import parse_pause_markers
+
+
+SOURCE_REVISION = "3d2bd9d07bbe8d16c2439745b0ded450dc41e215"
+MODEL_REVISION = "c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+MODEL_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/"
+    "models--k2-fsa--OmniVoice/snapshots/"
+    "c5fdb5ccb189668d56333f77ba2629f4cd7535f4"
+)
+ALIGNER_PATH = Path(
+    "/home/mustafa/.cache/huggingface/hub/"
+    "models--Systran--faster-whisper-small.en/snapshots/"
+    "d1d751a5f8271d482d14ca55d9e2deeebbae577f"
+)
+REFERENCE_DIR = Path(
+    "/home/mustafa/Desktop/pythonprojects/gentest/data/tts/clone_sources/"
+    "12_male_american_accent_performance_references"
+)
+SEED = 1234
+SAMPLE_RATE = 24000
+FRAME_RATE = 25
+SAMPLES_PER_FRAME = 960
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    case_id: str
+    group: str
+    original_text: str
+    requested_pause_seconds: float
+    reference_basename: str
+    reference_text: str
+
+
+PRIMARY_TEXT = (
+    "The first result looked convincing. "
+    "The second test revealed a hidden timing problem."
+)
+SECONDARY_TEXT = (
+    "From a distance, the mechanism looks perfectly ordinary. "
+    "But the hidden timing is what makes the whole system work."
+)
+PRIMARY_REF_TEXT = (
+    "But through your camera you'll see like a bluish light flickering. "
+    "Because the camera receives the infrared radiation and then it converts "
+    "it into a color humans can see on the screen."
+)
+SECONDARY_REF_TEXT = (
+    "To the human eye, the light on the remote will just look blank. "
+    "But through your camera, you'll see like a bluish light flickering. "
+    "Because the camera receives the infrared radiation, and then it converts "
+    "it into a color humans can see on the screen."
+)
+
+
+def smoke_cases(include_secondary: bool) -> list[SmokeCase]:
+    cases = [
+        SmokeCase(
+            "primary_baseline",
+            "primary",
+            PRIMARY_TEXT,
+            0.0,
+            "explaining_sub_11s_24k.wav",
+            PRIMARY_REF_TEXT,
+        )
+    ]
+    boundary = "The first result looked convincing."
+    remainder = " The second test revealed a hidden timing problem."
+    for label, seconds in (("040", 0.4), ("080", 0.8), ("120", 1.2)):
+        cases.append(
+            SmokeCase(
+                f"primary_pause_{label}",
+                "primary",
+                f"{boundary}<pause:{seconds:.2f}>{remainder}",
+                seconds,
+                "explaining_sub_11s_24k.wav",
+                PRIMARY_REF_TEXT,
+            )
+        )
+    if include_secondary:
+        cases.extend(
+            [
+                SmokeCase(
+                    "secondary_baseline",
+                    "secondary",
+                    SECONDARY_TEXT,
+                    0.0,
+                    "explaining_24k.wav",
+                    SECONDARY_REF_TEXT,
+                ),
+                SmokeCase(
+                    "secondary_pause_080",
+                    "secondary",
+                    "From a distance, the mechanism looks perfectly ordinary."
+                    "<pause:0.80> But the hidden timing is what makes the whole "
+                    "system work.",
+                    0.8,
+                    "explaining_24k.wav",
+                    SECONDARY_REF_TEXT,
+                ),
+            ]
+        )
+    return cases
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def normalized_words(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+(?:'[a-z0-9]+)?", text.lower())
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def transcribe(aligner: WhisperModel, path: Path) -> dict:
+    segments, info = aligner.transcribe(
+        str(path),
+        language="en",
+        beam_size=5,
+        word_timestamps=True,
+    )
+    words = []
+    text_parts = []
+    for segment in segments:
+        text_parts.append(segment.text.strip())
+        for word in segment.words or []:
+            words.append(
+                {
+                    "word": word.word.strip(),
+                    "normalized": normalized_words(word.word)[0]
+                    if normalized_words(word.word)
+                    else "",
+                    "start": float(word.start),
+                    "end": float(word.end),
+                    "probability": float(word.probability),
+                }
+            )
+    text = " ".join(part for part in text_parts if part).strip()
+    return {
+        "text": text,
+        "normalized_words": [
+            word["normalized"] for word in words if word["normalized"]
+        ],
+        "words": words,
+        "language": info.language,
+        "language_probability": float(info.language_probability),
+    }
+
+
+def find_boundary_anchors(cleaned_text: str, offset: int, asr: dict) -> dict | None:
+    expected = normalized_words(cleaned_text)
+    preceding_count = len(normalized_words(cleaned_text[:offset]))
+    if preceding_count < 1 or preceding_count >= len(expected):
+        return None
+    actual = [word["normalized"] for word in asr["words"]]
+    matcher = difflib.SequenceMatcher(a=expected, b=actual, autojunk=False)
+    mapping = {}
+    for block in matcher.get_matching_blocks():
+        for delta in range(block.size):
+            mapping[block.a + delta] = block.b + delta
+    before_expected = preceding_count - 1
+    after_expected = preceding_count
+    if before_expected not in mapping or after_expected not in mapping:
+        return None
+    before = asr["words"][mapping[before_expected]]
+    after = asr["words"][mapping[after_expected]]
+    return {
+        "preceding_word": before,
+        "following_word": after,
+        "expected_preceding": expected[before_expected],
+        "expected_following": expected[after_expected],
+    }
+
+
+def low_energy_measurement(path: Path, anchors: dict | None) -> dict | None:
+    if anchors is None:
+        return None
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    start_seconds = anchors["preceding_word"]["end"]
+    end_seconds = anchors["following_word"]["start"]
+    start = max(0, int(start_seconds * sample_rate))
+    end = min(len(audio), int(end_seconds * sample_rate))
+    frame_samples = max(1, int(0.01 * sample_rate))
+    longest = 0
+    longest_start = 0
+    current = 0
+    current_start = 0
+    dbfs_values = []
+    for frame_start in range(start, end, frame_samples):
+        frame = audio[frame_start : min(frame_start + frame_samples, end)]
+        if len(frame) == 0:
+            continue
+        rms = float(np.sqrt(np.mean(np.square(frame, dtype=np.float64))))
+        dbfs = 20.0 * np.log10(max(rms, 1e-12))
+        dbfs_values.append(float(dbfs))
+        if dbfs < -50.0:
+            if current == 0:
+                current_start = frame_start
+            current += len(frame)
+            if current > longest:
+                longest = current
+                longest_start = current_start
+        else:
+            current = 0
+    longest_end = longest_start + longest
+    return {
+        "anchor_window_seconds": [start_seconds, end_seconds],
+        "asr_word_gap_seconds": max(0.0, end_seconds - start_seconds),
+        "longest_low_energy_seconds": longest / sample_rate,
+        "low_energy_start_seconds": longest_start / sample_rate,
+        "low_energy_end_seconds": longest_end / sample_rate,
+        "minimum_frame_dbfs": min(dbfs_values) if dbfs_values else None,
+    }
+
+
+def transient_measurement(path: Path, low_energy: dict | None) -> dict | None:
+    if low_energy is None or low_energy["longest_low_energy_seconds"] <= 0:
+        return None
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    delta = np.abs(np.diff(audio))
+    if len(delta) == 0:
+        return None
+    radius = int(0.05 * sample_rate)
+    values = []
+    for seconds in (
+        low_energy["low_energy_start_seconds"],
+        low_energy["low_energy_end_seconds"],
+    ):
+        center = int(seconds * sample_rate)
+        values.append(float(delta[max(0, center - radius) : center + radius].max()))
+    global_p999 = float(np.quantile(delta, 0.999))
+    boundary_max = max(values)
+    limit = max(0.25, global_p999 * 5.0)
+    return {
+        "entry_max_abs_delta": values[0],
+        "exit_max_abs_delta": values[1],
+        "global_p999_abs_delta": global_p999,
+        "abnormal_spike_limit": limit,
+        "abnormal_spike": boundary_max > limit,
+    }
+
+
+def git_revision(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+
+def generate_case(
+    model: OmniVoice,
+    prompt,
+    case: SmokeCase,
+    output_dir: Path,
+    num_step: int,
+) -> dict:
+    set_seed(SEED)
+    torch.cuda.reset_peak_memory_stats()
+    config = OmniVoiceGenerationConfig(num_step=num_step)
+    started = time.perf_counter()
+    task = model._preprocess_all(
+        text=case.original_text,
+        language="English",
+        voice_clone_prompt=prompt,
+        preprocess_prompt=config.preprocess_prompt,
+        speed=1.0,
+        duration=None,
+    )
+    with torch.inference_mode():
+        tokens = model._generate_iterative(task, config)[0]
+        raw = (
+            model.audio_tokenizer.decode(
+                tokens.to(model.audio_tokenizer.device).unsqueeze(0)
+            )
+            .audio_values[0]
+            .cpu()
+            .numpy()
+            .squeeze(0)
+        )
+        final = model._decode_and_post_process(
+            tokens,
+            task.ref_rms[0],
+            config,
+            preserve_internal_silence=bool(task.controlled[0]),
+        )
+    runtime = time.perf_counter() - started
+
+    raw_path = output_dir / f"{case.case_id}_raw.wav"
+    final_path = output_dir / f"{case.case_id}_final.wav"
+    token_path = output_dir / f"{case.case_id}_tokens.pt"
+    sf.write(raw_path, raw, model.sampling_rate, subtype="FLOAT")
+    sf.write(final_path, final, model.sampling_rate, subtype="FLOAT")
+    torch.save(tokens.cpu(), token_path)
+
+    cleaned_text, canonical_plan = parse_pause_markers(case.original_text)
+    spans = task.pause_spans[0]
+    fixed_unchanged = True
+    if task.target_templates[0] is not None:
+        template = task.target_templates[0]
+        fixed = template != model.config.audio_mask_id
+        fixed_unchanged = bool(torch.equal(tokens[fixed], template[fixed]))
+    return {
+        "case_id": case.case_id,
+        "group": case.group,
+        "original_text": case.original_text,
+        "cleaned_text": cleaned_text,
+        "canonical_plan": asdict(canonical_plan),
+        "requested_pause_seconds": case.requested_pause_seconds,
+        "requested_pause_frames": sum(end - start for start, end in spans),
+        "pause_token_spans": [list(span) for span in spans],
+        "target_frames": task.target_lens[0],
+        "raw_samples": len(raw),
+        "final_samples": len(final),
+        "exact_raw_codec_length": len(raw) == task.target_lens[0] * SAMPLES_PER_FRAME,
+        "fixed_tokens_unchanged": fixed_unchanged,
+        "seed": SEED,
+        "speed": 1.0,
+        "duration": None,
+        "language": "English",
+        "num_step": num_step,
+        "runtime_seconds": runtime,
+        "gpu_peak_memory_bytes": torch.cuda.max_memory_allocated(),
+        "files": {
+            "raw": str(raw_path),
+            "final": str(final_path),
+            "tokens": str(token_path),
+        },
+        "hashes": {
+            "raw_sha256": sha256(raw_path),
+            "final_sha256": sha256(final_path),
+            "tokens_sha256": sha256(token_path),
+        },
+    }
+
+
+def add_measurements(aligner: WhisperModel, result: dict) -> None:
+    cleaned = result["cleaned_text"]
+    pauses = result["canonical_plan"]["pauses"]
+    offset = pauses[0]["after_char"] if pauses else cleaned.find(". ") + 1
+    for kind in ("raw", "final"):
+        path = Path(result["files"][kind])
+        asr = transcribe(aligner, path)
+        anchors = find_boundary_anchors(cleaned, offset, asr)
+        low_energy = low_energy_measurement(path, anchors)
+        result.setdefault("asr", {})[kind] = asr
+        result.setdefault("boundary_anchors", {})[kind] = anchors
+        result.setdefault("pause_measurements", {})[kind] = low_energy
+        result.setdefault("transient_metrics", {})[kind] = transient_measurement(
+            path, low_energy
+        )
+
+
+def evaluate_group(results: list[dict]) -> None:
+    by_group = {}
+    for result in results:
+        by_group.setdefault(result["group"], []).append(result)
+    for group_results in by_group.values():
+        baseline = next(
+            item for item in group_results if not item["canonical_plan"]["pauses"]
+        )
+        for result in group_results:
+            for kind in ("raw", "final"):
+                current_measure = result["pause_measurements"][kind]
+                baseline_measure = baseline["pause_measurements"][kind]
+                current_span = (
+                    current_measure["longest_low_energy_seconds"]
+                    if current_measure
+                    else None
+                )
+                baseline_span = (
+                    baseline_measure["longest_low_energy_seconds"]
+                    if baseline_measure
+                    else None
+                )
+                incremental = (
+                    current_span - baseline_span
+                    if current_span is not None and baseline_span is not None
+                    else None
+                )
+                if result["pause_measurements"][kind] is None:
+                    result["pause_measurements"][kind] = {}
+                result["pause_measurements"][kind]["baseline_relative_seconds"] = (
+                    incremental
+                )
+            baseline_words = baseline["asr"]["raw"]["normalized_words"]
+            current_words = result["asr"]["raw"]["normalized_words"]
+            result["word_order_matches_baseline"] = current_words == baseline_words
+            result["wer_vs_baseline"] = jiwer.wer(
+                " ".join(baseline_words), " ".join(current_words)
+            )
+            if result["canonical_plan"]["pauses"]:
+                requested = result["requested_pause_seconds"]
+                raw_incremental = result["pause_measurements"]["raw"][
+                    "baseline_relative_seconds"
+                ]
+                final_incremental = result["pause_measurements"]["final"][
+                    "baseline_relative_seconds"
+                ]
+                anchors_ok = all(
+                    result["boundary_anchors"][kind] is not None
+                    for kind in ("raw", "final")
+                )
+                transients_ok = all(
+                    result["transient_metrics"][kind] is not None
+                    and not result["transient_metrics"][kind]["abnormal_spike"]
+                    for kind in ("raw", "final")
+                )
+                result["pass_checks"] = {
+                    "exact_requested_codec_frames": result["requested_pause_frames"]
+                    == int(np.floor(requested * FRAME_RATE + 0.5)),
+                    "raw_pause_within_120ms": raw_incremental is not None
+                    and abs(raw_incremental - requested) <= 0.12,
+                    "final_pause_within_120ms": final_incremental is not None
+                    and abs(final_incremental - requested) <= 0.12,
+                    "boundary_words_present": anchors_ok,
+                    "word_sequence_matches_baseline": result[
+                        "word_order_matches_baseline"
+                    ],
+                    "no_boundary_word_omission_or_duplication": anchors_ok
+                    and result["word_order_matches_baseline"],
+                    "fixed_tokens_unchanged": result["fixed_tokens_unchanged"],
+                    "no_abnormal_transient_spike": transients_ok,
+                }
+                result["automated_pass"] = all(result["pass_checks"].values())
+            else:
+                result["pass_checks"] = {}
+                result["automated_pass"] = True
+
+
+def relative_output_paths(results: list[dict], root: Path) -> None:
+    for result in results:
+        result["files"] = {
+            key: str(Path(value).resolve().relative_to(root.resolve()))
+            for key, value in result["files"].items()
+        }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preset", choices=("quick", "acceptance"), default="quick")
+    parser.add_argument("--num-step", type=int)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--model-path", type=Path, default=MODEL_PATH)
+    parser.add_argument("--aligner-path", type=Path, default=ALIGNER_PATH)
+    parser.add_argument("--reference-dir", type=Path, default=REFERENCE_DIR)
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    num_step = args.num_step or (32 if args.preset == "quick" else 128)
+    output_dir = args.output_dir or root / "outputs" / "pause_smoke" / args.preset
+    report_path = args.report or output_dir / "pause_smoke_results.json"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    torch.cuda.reset_peak_memory_stats()
+    model = OmniVoice.from_pretrained(
+        str(args.model_path), device_map="cuda:0", dtype=torch.float16
+    )
+    prompt_cache = {}
+    cases = smoke_cases(include_secondary=args.preset == "acceptance")
+    results = []
+    for case in cases:
+        if args.preset == "quick" and case.requested_pause_seconds not in (0.0, 0.8):
+            continue
+        if case.reference_basename not in prompt_cache:
+            reference_path = args.reference_dir / case.reference_basename
+            prompt_cache[case.reference_basename] = model.create_voice_clone_prompt(
+                str(reference_path), case.reference_text
+            )
+        result = generate_case(
+            model,
+            prompt_cache[case.reference_basename],
+            case,
+            output_dir,
+            num_step,
+        )
+        result["reference_basename"] = case.reference_basename
+        result["reference_sha256"] = sha256(
+            args.reference_dir / case.reference_basename
+        )
+        results.append(result)
+
+    aligner = WhisperModel(
+        str(args.aligner_path),
+        device="cpu",
+        compute_type="int8",
+        local_files_only=True,
+    )
+    for result in results:
+        add_measurements(aligner, result)
+    evaluate_group(results)
+    relative_output_paths(results, root)
+
+    controlled = [item for item in results if item["canonical_plan"]["pauses"]]
+    automated_pass = bool(controlled) and all(
+        item["automated_pass"] for item in controlled
+    )
+    report = {
+        "format": "omnivoice_native_pause_smoke_v1",
+        "preset": args.preset,
+        "source_revision": SOURCE_REVISION,
+        "experiment_revision": git_revision(root),
+        "model_revision": MODEL_REVISION,
+        "aligner_revision": args.aligner_path.name,
+        "python": subprocess.check_output(
+            [str(root / ".venv/bin/python"), "--version"], text=True
+        ).strip(),
+        "torch": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(0),
+        "num_step": num_step,
+        "seed": SEED,
+        "automated_pass": automated_pass,
+        "listening_status": "manual review pending",
+        "decision": "one-pass accepted" if automated_pass else "two-pass required",
+        "cases": results,
+    }
+    report_path.write_text(json.dumps(report, indent=2) + "\n")
+    print(
+        json.dumps(
+            {
+                "report": str(report_path),
+                "automated_pass": automated_pass,
+                "decision": report["decision"],
+                "cases": {
+                    item["case_id"]: {
+                        "automated_pass": item["automated_pass"],
+                        "raw_incremental": item["pause_measurements"]["raw"].get(
+                            "baseline_relative_seconds"
+                        ),
+                        "final_incremental": item["pause_measurements"]["final"].get(
+                            "baseline_relative_seconds"
+                        ),
+                    }
+                    for item in results
+                },
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_narration_controls.py
+++ b/tests/test_narration_controls.py
@@ -6,6 +6,8 @@ import numpy as np
 from omnivoice.narration import (
     NarrationControl,
     _aligned_control_audio,
+    _apply_pronunciations,
+    _apply_pronunciations_to_pause_plan,
     _conditioned_text,
     _core_frame_target,
     _normalize_cmu_pronunciation,
@@ -19,6 +21,7 @@ from omnivoice.narration import (
     NarrationController,
     narration_capabilities,
 )
+from omnivoice.controls import PausePlan, PauseSpec
 
 
 def test_explicit_controls_clean_text_and_keep_offsets():
@@ -181,6 +184,30 @@ def test_cmu_pronunciation_can_protect_word_inside_multiword_control():
     assert _conditioned_text(plan.text, plan.controls[0], resolved[0]) == (
         "This was —an [AH2 N IH0 K S P EH1 K T IH0 D] result—."
     )
+
+
+def test_cmu_pronunciation_also_protects_words_outside_control():
+    plan = parse_narration_controls(
+        'Tony Soprano was <emphasis strength="strong">never ordinary</emphasis>.'
+    )
+    pronunciations = {"Soprano": "S AH0 P R AA1 N OW0"}
+
+    assert _resolve_pronunciations(plan, pronunciations) == {}
+    assert _apply_pronunciations(plan.text, pronunciations) == (
+        "Tony [S AH0 P R AA1 N OW0] was never ordinary."
+    )
+
+
+def test_cmu_replacement_remaps_native_pause_offset():
+    text = "Tony Soprano paused."
+    pause = PausePlan((PauseSpec(text.index(" paused"), 0.8),))
+
+    conditioned, remapped = _apply_pronunciations_to_pause_plan(
+        text, pause, {"Soprano": "S AH0 P R AA1 N OW0"}
+    )
+
+    assert conditioned == "Tony [S AH0 P R AA1 N OW0] paused."
+    assert conditioned[: remapped.pauses[0].after_char].endswith("]")
 
 
 def test_generate_plan_rejects_non_plan_before_loading_model():

--- a/tests/test_narration_controls.py
+++ b/tests/test_narration_controls.py
@@ -13,6 +13,7 @@ from omnivoice.narration import (
     _normalize_cmu_pronunciation,
     _resolve_pronunciations,
     _shift_fixed_spans,
+    _transition_frames_around_fixed_spans,
     _transcribe,
     align_expected_words,
     build_inpaint_template,
@@ -249,6 +250,21 @@ def test_fixed_pause_spans_shift_or_reject_overlap():
     assert _shift_fixed_spans(((3, 5), (15, 18)), (8, 12), 7) == ((3, 5), (18, 21))
     with pytest.raises(ValueError, match="fixed pause"):
         _shift_fixed_spans(((9, 11),), (8, 12), 7)
+
+
+def test_inpaint_transition_stops_at_adjacent_fixed_pause():
+    assert _transition_frames_around_fixed_spans(10, 20, ((20, 40),)) == (5, 0)
+    template, window, core = build_inpaint_template(
+        torch.arange(80).reshape(8, 10),
+        2,
+        5,
+        4,
+        mask_id=99,
+        transition_frames=(2, 0),
+    )
+    assert window == (0, 5)
+    assert core == (2, 6)
+    assert template.shape == (8, 11)
 
 
 def test_numpy_audio_is_resampled_to_whisper_sample_rate():

--- a/tests/test_narration_controls.py
+++ b/tests/test_narration_controls.py
@@ -1,0 +1,184 @@
+import pytest
+import torch
+from types import SimpleNamespace
+import numpy as np
+
+from omnivoice.narration import (
+    NarrationControl,
+    _aligned_control_audio,
+    _conditioned_text,
+    _core_frame_target,
+    _shift_fixed_spans,
+    _transcribe,
+    align_expected_words,
+    build_inpaint_template,
+    control_word_indices,
+    parse_narration_controls,
+)
+
+
+def test_explicit_controls_clean_text_and_keep_offsets():
+    plan = parse_narration_controls(
+        'This was <emphasis strength="strong">not</emphasis> ordinary. '
+        '<rate value="0.85">Read this slowly.</rate> '
+        '<intonation type="falling">That was final?</intonation>'
+    )
+    assert plan.text == "This was not ordinary. Read this slowly. That was final?"
+    assert [
+        (item.kind, plan.text[item.start_char : item.end_char])
+        for item in plan.controls
+    ] == [
+        ("emphasis", "not"),
+        ("rate", "Read this slowly."),
+        ("intonation", "That was final?"),
+    ]
+    assert [item.value for item in plan.controls] == ["strong", 0.85, "falling"]
+
+
+def test_pause_and_narration_controls_share_cleaned_text():
+    plan = parse_narration_controls(
+        "First.<pause:0.60> <aside>Apparently this mattered.</aside>"
+    )
+    assert plan.text == "First. Apparently this mattered."
+    assert plan.pause_plan.pauses[0].after_char == 6
+    assert plan.text[plan.controls[0].start_char : plan.controls[0].end_char] == (
+        "Apparently this mattered."
+    )
+
+
+def test_repeated_surface_maps_control_by_original_position():
+    plan = parse_narration_controls("foo <emphasis>foo</emphasis>")
+    control = plan.controls[0]
+    assert (control.start_char, control.end_char) == (4, 7)
+    assert plan.text[control.start_char : control.end_char] == "foo"
+
+
+def test_shorthand_is_optional_and_maps_to_controls():
+    source = "This was **not** normal. (At least for now.) The answer — absolutely — changed."
+    plain = parse_narration_controls(source, shorthand=False)
+    assert plain.controls == ()
+    assert plain.text == source
+
+    plan = parse_narration_controls(source, shorthand=True)
+    assert [(item.kind, item.value, item.source) for item in plan.controls] == [
+        ("emphasis", "moderate", "shorthand"),
+        ("aside", "parenthetical", "shorthand"),
+        ("emphasis", "strong", "dash"),
+    ]
+    assert (
+        plan.text
+        == "This was not normal. At least for now. The answer absolutely changed."
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<rate value="0.2">Too fast.</rate>',
+        '<rate value="abc">Bad.</rate>',
+        '<emphasis strength="extreme">No.</emphasis>',
+        '<intonation type="flat">No.</intonation>',
+        '<aside unknown="x">No.</aside>',
+        "<emphasis>missing close",
+        "<emphasis><aside>nested</aside></emphasis>",
+        "<aside>text<pause:0.4></aside> after",
+    ],
+)
+def test_invalid_controls_raise(text):
+    with pytest.raises(ValueError):
+        parse_narration_controls(text)
+
+
+def test_control_word_indices_uses_character_overlap():
+    text = "The hidden timing changed everything."
+    start = text.index("hidden")
+    control = NarrationControl(
+        "emphasis", start, start + len("hidden timing"), "strong"
+    )
+    assert control_word_indices(text, control) == (1, 2)
+
+
+def test_expected_word_alignment_maps_matching_blocks():
+    expected = ["the", "hidden", "timing", "changed"]
+    asr = [
+        {"normalized": "the"},
+        {"normalized": "hidden"},
+        {"normalized": "timing"},
+        {"normalized": "changed"},
+    ]
+    assert align_expected_words(expected, asr) == {0: 0, 1: 1, 2: 2, 3: 3}
+
+
+def test_inpaint_template_preserves_every_outside_token():
+    tokens = torch.arange(2 * 20).view(2, 20)
+    template, old_window, new_core = build_inpaint_template(
+        tokens, 8, 12, 6, mask_id=99, transition_frames=2
+    )
+    assert old_window == (6, 14)
+    assert new_core == (8, 14)
+    assert template.shape == (2, 22)
+    assert torch.equal(template[:, :6], tokens[:, :6])
+    assert torch.all(template[:, 6:16] == 99)
+    assert torch.equal(template[:, 16:], tokens[:, 14:])
+
+
+def test_control_frame_targets_match_requested_behavior():
+    assert _core_frame_target(NarrationControl("rate", 0, 1, 1.25), 20) == 16
+    assert _core_frame_target(NarrationControl("rate", 0, 1, 0.8), 20) == 25
+    assert _core_frame_target(NarrationControl("emphasis", 0, 1, "moderate"), 20) == 23
+    assert _core_frame_target(NarrationControl("emphasis", 0, 1, "strong"), 20) == 27
+    assert _core_frame_target(NarrationControl("intonation", 0, 1, "rising"), 20) == 20
+
+
+def test_conditioned_text_adds_model_cues_without_changing_surface_words():
+    text = "This was not ordinary."
+    start = text.index("not")
+    strong = NarrationControl("emphasis", start, start + 3, "strong")
+    assert _conditioned_text(text, strong) == "This was —NOT— ordinary."
+    rising = NarrationControl("intonation", 0, len(text), "rising")
+    assert _conditioned_text(text, rising) == "This was not ordinary?"
+
+
+def test_fixed_pause_spans_shift_or_reject_overlap():
+    assert _shift_fixed_spans(((3, 5), (15, 18)), (8, 12), 7) == ((3, 5), (18, 21))
+    with pytest.raises(ValueError, match="fixed pause"):
+        _shift_fixed_spans(((9, 11),), (8, 12), 7)
+
+
+def test_numpy_audio_is_resampled_to_whisper_sample_rate():
+    class FakeAligner:
+        def transcribe(self, audio, **kwargs):
+            assert len(audio) == 16000
+            return [], SimpleNamespace(language="en", language_probability=1.0)
+
+    result = _transcribe(FakeAligner(), np.zeros(24000, dtype=np.float32), 24000)
+    assert result["words"] == []
+
+
+def test_intonation_metrics_use_three_word_ending_context():
+    text = "The hidden timing changed everything."
+    control = NarrationControl("intonation", 0, len(text), "rising")
+    words = []
+    cursor = 0.0
+    for word in ["the", "hidden", "timing", "changed", "everything"]:
+        words.append(
+            {
+                "word": word,
+                "normalized": word,
+                "start": cursor,
+                "end": cursor + 0.2,
+                "probability": 1.0,
+            }
+        )
+        cursor += 0.2
+    transcript = {"words": words}
+    metrics = _aligned_control_audio(
+        text,
+        control,
+        transcript,
+        np.zeros(24000, dtype=np.float32),
+        24000,
+    )
+    assert metrics is not None
+    assert metrics["first_word_index"] == 2
+    assert metrics["last_word_index"] == 4

--- a/tests/test_narration_controls.py
+++ b/tests/test_narration_controls.py
@@ -16,6 +16,8 @@ from omnivoice.narration import (
     build_inpaint_template,
     control_word_indices,
     parse_narration_controls,
+    NarrationController,
+    narration_capabilities,
 )
 
 
@@ -163,6 +165,40 @@ def test_cmu_pronunciation_normalization_and_control_resolution():
         plan,
         {"unexpected": "AH2 N IH0 K S P EH1 K T IH0 D"},
     ) == {0: "[AH2 N IH0 K S P EH1 K T IH0 D]"}
+
+
+def test_cmu_pronunciation_can_protect_word_inside_multiword_control():
+    plan = parse_narration_controls(
+        'This was <emphasis strength="strong">an unexpected result</emphasis>.'
+    )
+    resolved = _resolve_pronunciations(
+        plan,
+        {"unexpected": "AH2 N IH0 K S P EH1 K T IH0 D"},
+    )
+    assert resolved == {
+        0: ((3, 13, "[AH2 N IH0 K S P EH1 K T IH0 D]"),)
+    }
+    assert _conditioned_text(plan.text, plan.controls[0], resolved[0]) == (
+        "This was —an [AH2 N IH0 K S P EH1 K T IH0 D] result—."
+    )
+
+
+def test_generate_plan_rejects_non_plan_before_loading_model():
+    controller = NarrationController(SimpleNamespace())
+    with pytest.raises(TypeError, match="NarrationPlan"):
+        controller.generate_plan("not a plan")
+
+
+def test_narration_capabilities_are_stable_and_defensively_copied():
+    first = narration_capabilities()
+    first["regional_controls"]["emphasis"]["values"].append("fake")
+    second = narration_capabilities()
+    assert second["frame_rate"] == 25
+    assert second["regional_controls"]["emphasis"]["values"] == [
+        "reduced",
+        "moderate",
+        "strong",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_narration_controls.py
+++ b/tests/test_narration_controls.py
@@ -8,6 +8,8 @@ from omnivoice.narration import (
     _aligned_control_audio,
     _conditioned_text,
     _core_frame_target,
+    _normalize_cmu_pronunciation,
+    _resolve_pronunciations,
     _shift_fixed_spans,
     _transcribe,
     align_expected_words,
@@ -137,6 +139,47 @@ def test_conditioned_text_adds_model_cues_without_changing_surface_words():
     assert _conditioned_text(text, strong) == "This was —NOT— ordinary."
     rising = NarrationControl("intonation", 0, len(text), "rising")
     assert _conditioned_text(text, rising) == "This was not ordinary?"
+
+
+def test_conditioned_text_can_use_cmu_without_changing_alignment_text():
+    text = "This was unexpected."
+    start = text.index("unexpected")
+    control = NarrationControl("emphasis", start, start + 10, "strong")
+    pronunciation = "[AH2 N IH0 K S P EH1 K T IH0 D]"
+    assert _conditioned_text(text, control, pronunciation) == (
+        "This was —[AH2 N IH0 K S P EH1 K T IH0 D]—."
+    )
+
+
+def test_cmu_pronunciation_normalization_and_control_resolution():
+    assert (
+        _normalize_cmu_pronunciation("ah2 n ih0 k s p eh1 k t ih0 d")
+        == "[AH2 N IH0 K S P EH1 K T IH0 D]"
+    )
+    plan = parse_narration_controls(
+        'This was <emphasis strength="strong">unexpected</emphasis>.'
+    )
+    assert _resolve_pronunciations(
+        plan,
+        {"unexpected": "AH2 N IH0 K S P EH1 K T IH0 D"},
+    ) == {0: "[AH2 N IH0 K S P EH1 K T IH0 D]"}
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "[AH2 N", "AH N", "N1 OW1", "XX1"],
+)
+def test_invalid_cmu_pronunciations_raise(value):
+    with pytest.raises((TypeError, ValueError)):
+        _normalize_cmu_pronunciation(value)
+
+
+def test_pronunciation_key_must_match_controlled_surface():
+    plan = parse_narration_controls(
+        'This was <emphasis strength="strong">unexpected</emphasis>.'
+    )
+    with pytest.raises(ValueError, match="controlled span"):
+        _resolve_pronunciations(plan, {"nobody": "N OW1 B AA2 D IY2"})
 
 
 def test_fixed_pause_spans_shift_or_reject_overlap():

--- a/tests/test_pause_controls.py
+++ b/tests/test_pause_controls.py
@@ -205,7 +205,12 @@ def test_room_tone_is_mono_center_cropped_and_validated():
 
 class _DiffusionHarness:
     device = torch.device("cpu")
-    config = SimpleNamespace(num_audio_codebook=2, audio_mask_id=4)
+    config = SimpleNamespace(
+        num_audio_codebook=2,
+        audio_mask_id=4,
+        audio_codebook_weights=[2, 1],
+    )
+    audio_tokenizer = SimpleNamespace(config=SimpleNamespace(frame_rate=25))
 
     def __init__(self):
         self.inputs = []
@@ -237,10 +242,19 @@ class _DiffusionHarness:
         logits = torch.zeros((*input_ids.shape, 5), dtype=torch.float32)
         return SimpleNamespace(logits=logits)
 
-    def _predict_tokens_with_scoring(self, c_logits, u_logits, gen_config):
+    def _predict_tokens_with_scoring(
+        self, c_logits, u_logits, gen_config, return_diagnostics=False
+    ):
         shape = c_logits.shape[:-1]
         pred = torch.ones(shape, dtype=torch.long)
         scores = torch.arange(pred.numel(), dtype=torch.float32).view(shape)
+        if return_diagnostics:
+            log_probs = torch.log_softmax(c_logits, dim=-1)
+            return pred, scores, {
+                "log_probs": log_probs,
+                "c_log_probs": log_probs,
+                "u_log_probs": torch.log_softmax(u_logits, dim=-1),
+            }
         return pred, scores
 
     _generate_iterative = OmniVoice._generate_iterative
@@ -304,6 +318,34 @@ def test_mixed_mask_counts_keep_schedule_and_topk_safe():
     )
     assert [tuple(output.shape) for output in outputs] == [(2, 3), (2, 5)]
     assert all(torch.all(output != 4) for output in outputs)
+
+
+def test_generation_trace_records_only_unmasked_positions_without_changing_tokens():
+    template = torch.full((2, 5), 4, dtype=torch.long)
+    template[:, 1:3] = torch.tensor([[2, 3], [1, 2]])
+    config = OmniVoiceGenerationConfig(
+        num_step=3, position_temperature=0.0, layer_penalty_factor=0.0
+    )
+    plain = _DiffusionHarness()._generate_iterative(
+        _diffusion_task(template), config
+    )[0]
+    trace = []
+    traced = _DiffusionHarness()._generate_iterative(
+        _diffusion_task(template), config, trace=trace
+    )[0]
+    assert torch.equal(plain, traced)
+    assert len(trace) == 1
+    item = trace[0]
+    fixed = template != 4
+    assert item["format"] == "omnivoice_generation_trace_v1"
+    assert item["tokens"].shape == template.shape
+    assert torch.all(item["unmask_step"][fixed] == -1)
+    assert torch.all(item["unmask_step"][~fixed] > 0)
+    assert torch.isnan(item["token_logprob"][fixed]).all()
+    assert torch.isfinite(item["token_logprob"][~fixed]).all()
+    assert torch.isfinite(item["entropy"][~fixed]).all()
+    assert torch.isfinite(item["cfg_delta"][~fixed]).all()
+    assert torch.equal(item["pause"], fixed)
 
 
 def test_controlled_postprocessing_preserves_internal_silence():

--- a/tests/test_pause_controls.py
+++ b/tests/test_pause_controls.py
@@ -1,0 +1,335 @@
+import inspect
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from omnivoice import OmniVoice, PausePlan, PauseSpec
+from omnivoice.controls import (
+    PauseLayout,
+    canonicalize_pause_plan,
+    create_pause_layout,
+    parse_pause_markers,
+    pause_seconds_to_frames,
+)
+from omnivoice.models.omnivoice import GenerationTask, OmniVoiceGenerationConfig
+
+
+def test_inline_markers_strip_and_preserve_structured_offsets():
+    cleaned, plan = parse_pause_markers(
+        "First  <pause:0.40>   second<pause:0.80>third."
+    )
+    assert cleaned == "First secondthird."
+    assert plan == PausePlan((PauseSpec(5, 0.4), PauseSpec(12, 0.8)))
+    assert cleaned[: plan.pauses[0].after_char] == "First"
+
+
+def test_adjacent_markers_merge_at_same_offset():
+    cleaned, plan = parse_pause_markers("Hello <pause:0.40> <pause:0.80> world")
+    assert cleaned == "Hello world"
+    assert len(plan.pauses) == 1
+    assert plan.pauses[0].after_char == 5
+    assert plan.pauses[0].seconds == pytest.approx(1.2)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<pause:0.4>Hello",
+        "Hello<pause:0.4>",
+        "Hello<pause:0>world",
+        "Hello<pause:-1>world",
+        "Hello<pause:nan>world",
+        "Hello<pause:inf>world",
+        "Hello<pause: 0.4>world",
+        "Hello<pause:abc>world",
+        "Hello<pause:0.4world",
+        "Hello<pause foo>world",
+    ],
+)
+def test_invalid_inline_markers_raise(text):
+    with pytest.raises(ValueError):
+        parse_pause_markers(text)
+
+
+def test_explicit_plan_sorts_merges_and_rejects_edges():
+    plan = canonicalize_pause_plan(
+        "alpha beta gamma",
+        PausePlan((PauseSpec(10, 0.2), PauseSpec(5, 0.4), PauseSpec(5, 0.1))),
+    )
+    assert plan.pauses == (PauseSpec(5, 0.5), PauseSpec(10, 0.2))
+    for offset in (0, len("alpha beta gamma")):
+        with pytest.raises(ValueError):
+            canonicalize_pause_plan(
+                "alpha beta gamma", PausePlan((PauseSpec(offset, 0.4),))
+            )
+
+
+def test_half_up_frame_conversion():
+    assert pause_seconds_to_frames(0.02) == 1
+    assert pause_seconds_to_frames(0.06) == 2
+    assert pause_seconds_to_frames(0.40) == 10
+    with pytest.raises(ValueError):
+        pause_seconds_to_frames(0.001)
+
+
+def test_speed_changes_only_speech_frames():
+    plan = PausePlan((PauseSpec(5, 0.4),))
+    normal = create_pause_layout("alpha beta", plan, 100, 1.0, None, 25, len)
+    fast = create_pause_layout("alpha beta", plan, 100, 2.0, None, 25, len)
+    assert normal.speech_frames == 100
+    assert fast.speech_frames == 50
+    assert normal.pause_frames == fast.pause_frames == (10,)
+    assert normal.total_frames == 110
+    assert fast.total_frames == 60
+
+
+def test_duration_is_final_total_and_pause_consumes_it():
+    plan = PausePlan((PauseSpec(5, 0.8),))
+    layout = create_pause_layout("alpha beta", plan, 100, 3.0, 2.0, 25, len)
+    assert layout.total_frames == 50
+    assert layout.pause_frames == (20,)
+    assert layout.speech_frames == 30
+
+
+def test_duration_rejects_too_few_phrase_frames():
+    plan = PausePlan((PauseSpec(1, 0.4), PauseSpec(2, 0.4)))
+    with pytest.raises(ValueError, match="one speech frame"):
+        create_pause_layout("abc", plan, 10, 1.0, 0.84, 25, len)
+
+
+def test_cumulative_weight_allocation_is_monotonic_and_exact():
+    plan = PausePlan((PauseSpec(1, 0.4), PauseSpec(3, 0.4)))
+    weights = {"a": 1.0, "bb": 2.0, "cccc": 4.0}
+    layout = create_pause_layout(
+        "abbcccc", plan, 70, 1.0, None, 25, lambda text: weights[text]
+    )
+    assert layout.phrase_frames == (10, 20, 40)
+    assert sum(layout.phrase_frames) == layout.speech_frames
+
+
+class _FakeAudioTokenizer:
+    device = torch.device("cpu")
+    config = SimpleNamespace(frame_rate=25)
+
+    def __init__(self):
+        self.waveforms = []
+
+    def encode(self, waveform):
+        self.waveforms.append(waveform.clone())
+        frames = waveform.shape[-1] // 960
+        codes = torch.arange(8).view(1, 8, 1).expand(1, 8, frames).clone()
+        return SimpleNamespace(audio_codes=codes)
+
+
+class _TemplateHarness:
+    device = torch.device("cpu")
+    sampling_rate = 24000
+    config = SimpleNamespace(num_audio_codebook=8, audio_mask_id=1024)
+
+    def __init__(self):
+        self.audio_tokenizer = _FakeAudioTokenizer()
+
+    _encode_pause_tokens = OmniVoice._encode_pause_tokens
+    _create_pause_template = OmniVoice._create_pause_template
+    _load_pause_source = OmniVoice._load_pause_source
+
+
+class _PreprocessHarness(_TemplateHarness):
+    duration_estimator = SimpleNamespace(calculate_total_weight=lambda text: len(text))
+
+    _preprocess_all = OmniVoice._preprocess_all
+    _normalize_pause_plans = OmniVoice._normalize_pause_plans
+    _ensure_list = OmniVoice._ensure_list
+
+    def _estimate_target_tokens(self, text, ref_text, ref_tokens, speed=1.0):
+        return max(1, int(20 / speed))
+
+
+def test_preprocess_batch_requires_matching_plan_list_and_supports_none_items():
+    model = _PreprocessHarness()
+    plan = PausePlan((PauseSpec(5, 0.4),))
+    with pytest.raises(ValueError, match="requires a pause_plan list"):
+        model._preprocess_all(["alpha beta", "plain text"], pause_plan=plan)
+    with pytest.raises(ValueError, match="match text batch size"):
+        model._preprocess_all(["alpha beta", "plain text"], pause_plan=[plan])
+
+    task = model._preprocess_all(["alpha beta", "plain text"], pause_plan=[plan, None])
+    assert task.controlled == [True, False]
+    assert task.target_lens == [30, 20]
+    assert task.pause_spans == [((10, 20),), ()]
+    assert task.target_templates[1] is None
+
+
+def test_preprocess_rejects_explicit_plan_with_inline_marker():
+    model = _PreprocessHarness()
+    with pytest.raises(ValueError, match="Cannot combine"):
+        model._preprocess_all(
+            "alpha<pause:0.4> beta",
+            pause_plan=PausePlan((PauseSpec(5, 0.4),)),
+        )
+
+
+def test_digital_silence_template_spans_all_eight_codebooks():
+    model = _TemplateHarness()
+    layout = PauseLayout(5, 15, (2, 3), (10,))
+    template, spans = model._create_pause_template(layout, None, {})
+    assert template.shape == (8, 15)
+    assert spans == ((2, 12),)
+    assert torch.all(template[:, :2] == 1024)
+    assert torch.all(template[:, 12:] == 1024)
+    assert torch.equal(template[:, 2:12], torch.arange(8).view(8, 1).expand(8, 10))
+    assert model.audio_tokenizer.waveforms[0].shape == (1, 1, 10 * 960)
+    assert torch.count_nonzero(model.audio_tokenizer.waveforms[0]) == 0
+
+
+def test_room_tone_is_mono_center_cropped_and_validated():
+    model = _TemplateHarness()
+    stereo = torch.stack((torch.arange(20000), torch.arange(20000) + 2)).float()
+    source = model._load_pause_source((stereo, 24000), 10)
+    tokens = model._encode_pause_tokens(10, source)
+    encoded = model.audio_tokenizer.waveforms[-1]
+    assert tokens.shape == (8, 10)
+    assert encoded.shape[-1] == 9600
+    expected = stereo.mean(0)[(20000 - 9600) // 2 : (20000 + 9600) // 2]
+    assert torch.equal(encoded[0, 0], expected)
+    with pytest.raises(ValueError, match="shorter"):
+        model._load_pause_source((torch.zeros(100), 24000), 10)
+    bad = torch.zeros(10000)
+    bad[0] = math.nan
+    with pytest.raises(ValueError, match="nonfinite"):
+        model._load_pause_source((bad, 24000), 10)
+
+
+class _DiffusionHarness:
+    device = torch.device("cpu")
+    config = SimpleNamespace(num_audio_codebook=2, audio_mask_id=4)
+
+    def __init__(self):
+        self.inputs = []
+
+    def _prepare_inference_inputs(
+        self,
+        text,
+        num_target_tokens,
+        ref_text,
+        ref_audio_tokens,
+        lang,
+        instruct,
+        denoise,
+        target_template,
+    ):
+        target = (
+            target_template.clone()
+            if target_template is not None
+            else torch.full((2, num_target_tokens), 4, dtype=torch.long)
+        )
+        prefix = torch.zeros((2, 2), dtype=torch.long)
+        ids = torch.cat((prefix, target), dim=1).unsqueeze(0)
+        mask = torch.zeros((1, ids.shape[-1]), dtype=torch.bool)
+        mask[:, 2:] = True
+        return {"input_ids": ids, "audio_mask": mask}
+
+    def __call__(self, input_ids, audio_mask, attention_mask):
+        self.inputs.append(input_ids.clone())
+        logits = torch.zeros((*input_ids.shape, 5), dtype=torch.float32)
+        return SimpleNamespace(logits=logits)
+
+    def _predict_tokens_with_scoring(self, c_logits, u_logits, gen_config):
+        shape = c_logits.shape[:-1]
+        pred = torch.ones(shape, dtype=torch.long)
+        scores = torch.arange(pred.numel(), dtype=torch.float32).view(shape)
+        return pred, scores
+
+    _generate_iterative = OmniVoice._generate_iterative
+
+
+def _diffusion_task(template):
+    return GenerationTask(
+        batch_size=1,
+        texts=["test"],
+        target_lens=[template.shape[-1]],
+        langs=[None],
+        instructs=[None],
+        ref_texts=[None],
+        ref_audio_tokens=[None],
+        ref_rms=[None],
+        target_templates=[template],
+        pause_spans=[((1, 3),)],
+        controlled=[True],
+    )
+
+
+def test_cfg_inputs_share_template_and_fixed_tokens_never_change():
+    model = _DiffusionHarness()
+    template = torch.full((2, 5), 4, dtype=torch.long)
+    template[:, 1:3] = torch.tensor([[2, 3], [1, 2]])
+    output = model._generate_iterative(
+        _diffusion_task(template),
+        OmniVoiceGenerationConfig(
+            num_step=3, position_temperature=0.0, layer_penalty_factor=0.0
+        ),
+    )[0]
+    first_input = model.inputs[0]
+    assert torch.equal(first_input[0, :, -5:], first_input[1, :, :5])
+    fixed = template != 4
+    assert torch.equal(output[fixed], template[fixed])
+    assert torch.all(output[~fixed] != 4)
+
+
+def test_mixed_mask_counts_keep_schedule_and_topk_safe():
+    model = _DiffusionHarness()
+    controlled = torch.tensor([[4, 2, 4], [4, 2, 4]])
+    uncontrolled = torch.full((2, 5), 4, dtype=torch.long)
+    task = GenerationTask(
+        batch_size=2,
+        texts=["a", "b"],
+        target_lens=[3, 5],
+        langs=[None, None],
+        instructs=[None, None],
+        ref_texts=[None, None],
+        ref_audio_tokens=[None, None],
+        ref_rms=[None, None],
+        target_templates=[controlled, uncontrolled],
+        pause_spans=[((1, 2),), ()],
+        controlled=[True, False],
+    )
+    outputs = model._generate_iterative(
+        task,
+        OmniVoiceGenerationConfig(
+            num_step=8, position_temperature=0.0, layer_penalty_factor=0.0
+        ),
+    )
+    assert [tuple(output.shape) for output in outputs] == [(2, 3), (2, 5)]
+    assert all(torch.all(output != 4) for output in outputs)
+
+
+def test_controlled_postprocessing_preserves_internal_silence():
+    model = SimpleNamespace(sampling_rate=24000)
+    tone = np.full((1, 12000), 0.2, dtype=np.float32)
+    silence = np.zeros((1, 48000), dtype=np.float32)
+    audio = np.concatenate((tone, silence, tone), axis=-1)
+    config = OmniVoiceGenerationConfig(pad_duration=0.0, fade_duration=0.0)
+    uncontrolled = OmniVoice._post_process_audio(model, audio, 0.1, config, False)
+    controlled = OmniVoice._post_process_audio(model, audio, 0.1, config, True)
+    assert controlled.shape[-1] > uncontrolled.shape[-1] + 12000
+
+
+def test_public_api_appends_pause_parameters_after_existing_parameters():
+    names = list(inspect.signature(OmniVoice.generate).parameters)
+    assert names[:11] == [
+        "self",
+        "text",
+        "language",
+        "ref_text",
+        "ref_audio",
+        "voice_clone_prompt",
+        "instruct",
+        "duration",
+        "speed",
+        "generation_config",
+        "pause_plan",
+    ]
+    assert names[11:] == ["pause_audio", "kwargs"]

--- a/tests/test_pause_smoke.py
+++ b/tests/test_pause_smoke.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from scripts.pause_smoke import (
+    find_boundary_anchors,
+    low_energy_measurement,
+    normalized_words,
+)
+
+
+def test_normalized_words_preserves_contractions_and_order():
+    assert normalized_words("It's ordinary. But timing matters!") == [
+        "it's",
+        "ordinary",
+        "but",
+        "timing",
+        "matters",
+    ]
+
+
+def test_boundary_anchor_mapping_uses_expected_word_sequence():
+    text = "The first result. The second test."
+    offset = text.index(". ") + 1
+    asr = {
+        "words": [
+            {"normalized": word, "start": i * 0.2, "end": i * 0.2 + 0.1}
+            for i, word in enumerate(normalized_words(text))
+        ]
+    }
+    anchors = find_boundary_anchors(text, offset, asr)
+    assert anchors["expected_preceding"] == "result"
+    assert anchors["expected_following"] == "the"
+    assert anchors["preceding_word"]["normalized"] == "result"
+    assert anchors["following_word"]["normalized"] == "the"
+
+
+def test_low_energy_measurement_finds_longest_10ms_run(tmp_path: Path):
+    sample_rate = 24000
+    audio = np.concatenate(
+        (
+            np.full(int(0.2 * sample_rate), 0.1, dtype=np.float32),
+            np.zeros(int(0.4 * sample_rate), dtype=np.float32),
+            np.full(int(0.2 * sample_rate), 0.1, dtype=np.float32),
+        )
+    )
+    path = tmp_path / "pause.wav"
+    sf.write(path, audio, sample_rate, subtype="FLOAT")
+    anchors = {
+        "preceding_word": {"end": 0.1},
+        "following_word": {"start": 0.7},
+    }
+    measurement = low_energy_measurement(path, anchors)
+    assert measurement["longest_low_energy_seconds"] == pytest.approx(0.4)
+    assert measurement["asr_word_gap_seconds"] == pytest.approx(0.6)

--- a/tests/test_pause_smoke.py
+++ b/tests/test_pause_smoke.py
@@ -7,6 +7,7 @@ import soundfile as sf
 from scripts.pause_smoke import (
     find_boundary_anchors,
     low_energy_measurement,
+    merge_windows,
     normalized_words,
 )
 
@@ -55,3 +56,7 @@ def test_low_energy_measurement_finds_longest_10ms_run(tmp_path: Path):
     measurement = low_energy_measurement(path, anchors)
     assert measurement["longest_low_energy_seconds"] == pytest.approx(0.4)
     assert measurement["asr_word_gap_seconds"] == pytest.approx(0.6)
+
+
+def test_transition_windows_merge_overlaps_and_touching_edges():
+    assert merge_windows([(8, 12), (3, 5), (5, 9), (20, 20)]) == [(3, 12)]


### PR DESCRIPTION
## Summary

- add codec-token-native pause controls to `OmniVoice.generate()` without waveform insertion
- add single-reference local rate, emphasis, intonation, and aside controls
- add optional CMU ARPABET conditioning for pronunciation-sensitive controls
- add fixed-token diffusion checks, generation traces, and standalone native diagnostics
- add reproducible smoke scripts and tracked acceptance reports

The implementation keeps one permanent voice-clone reference. It does not switch reference recordings or splice generated waveforms.

## Documentation

Full architecture, API examples, experiment history, validation commands, results, rejected approaches, and known limits are documented in [`docs/narration-control-experiments.md`](https://github.com/MustafaYumusakkaya/OmniVoice/blob/experiment/native-narration-controls/docs/narration-control-experiments.md).

The document also records the rejected protected-codebook pronunciation experiment: it improved content stability but weakened emphasis too much, so it is not included. CMU conditioning is the retained pronunciation strategy.

## Validation

- `65 passed` across pause, narration-control, and pause-smoke unit suites
- uncontrolled seeded output matches pristine `0.2.0` codec tokens exactly
- narration acceptance matrix preserves normalized word order and fixed tokens
- tracked results:
  - `reports/pause_smoke_results.json`
  - `reports/narration_control_results.json`
  - `reports/cmu_pronunciation_results.json`

`pip check` is not clean in the system-site-packages development environment because of pre-existing host conflicts, including missing `onnxruntime`. The focused test suites pass.

## Experimental status

This is a draft PR intentionally:

- exact fixed pause frames do not always produce pause duration within the strict 120 ms perceptual proxy after postprocessing
- the two-pass pause fallback repairs most, but not all, failing cases
- emphasis and intonation can be subtle and remain listening-gated
- ASR and waveform metrics cannot approve pronunciation, identity, clicks, artifacts, or transition naturalness
- current `NarrationController` scope is English short-form generation with a local faster-whisper aligner
- the branch started from OmniVoice `0.2.0`; current master may require integration work around later inference changes

No website or viewer integration is part of this PR.
