### PR TITLE
Fix: type of input waveform of `process()` in `denoise_audio.py` for single file process

### DIFF
--- a/omnivoice/scripts/denoise_audio.py
+++ b/omnivoice/scripts/denoise_audio.py
@@ -421,12 +421,12 @@ class SpeechDenoisingProcessor:
 
     @torch.inference_mode()
     def process(self, waveform: torch.Tensor, sample_rate: int) -> torch.Tensor:
-        return self.process_batch([waveform], [sample_rate])[0]
+        return self.process_batch(torch.unsqueeze(waveform, dim=0), [sample_rate])[0]
 
     @torch.inference_mode()
     def process_batch(
         self,
-        waveforms: Sequence[torch.Tensor] | torch.Tensor,
+        waveforms: torch.Tensor,
         sample_rates: Optional[Sequence[int]] = None,
         expected_lengths: Optional[Sequence[int]] = None,
     ) -> List[torch.Tensor]:


### PR DESCRIPTION
Minimal test code:
```py
processor = SpeechDenoisingProcessor(
    feature_extractor_path='sidon-v0.1/feature_extractor_cuda.pt',
    decoder_path='sidon-v0.1/decoder_cuda.pt',
    device='cuda',
)
audio, sr = soundfile.read("audio.wav")
audio = torch.from_numpy(audio).to('cuda')
processed_audio = processor.process(audio, sr)
```
The original implementation would raise an error at `waveforms = torch.nn.functional.pad(waveforms, (0, 24000))` where the waveforms would be a list but it expects a torch.tensor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech denoising support for individual audio waveforms.
  * Ensured audio inputs are handled consistently during batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->